### PR TITLE
Console shortcut

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,1 @@
+bundle exec pry -r ./spec/dummy/config/environment.rb

--- a/solidus_subscriptions.gemspec
+++ b/solidus_subscriptions.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop-rspec', '1.4.0'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'pry'
 end


### PR DESCRIPTION
Run The test app console with the extension loaded from the root of the directory with 

```bash
$ ./bin/console
```