### PR TITLE
Subscriptions state machine

### DIFF
--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -8,5 +8,66 @@ module SolidusSubscriptions
     has_many :installments, class_name: 'SolidusSubscriptions::Installment'
 
     validates :user, presence: :true
+
+    # The subscription state determines the behaviours around when it is
+    # processed. Here is a brief description of the states and how they affect
+    # the subscription.
+    #
+    # [active] Default state when created. Subscription can be processed
+    # [canceled] The user has ended their subscription. Subscription will not
+    #   be processed.
+    # [pending_cancellation] The user has ended their subscription, but the
+    #   conditions for canceling the subscription have not been met. Subscription
+    #   will continue to be processed until the subscription is canceled and
+    #   the conditions are met.
+    # [inactive] The number of installments has been fulfilled. The subscription
+    #   will no longer be processed
+    state_machine :state, initial: :active do
+      event :cancel do
+        transition [:active, :pending_cancellation] => :canceled,
+          if: ->(subscription) { subscription.can_be_canceled? }
+
+        transition active: :pending_cancellation
+      end
+
+      event :deactivate do
+        transition active: :inactive,
+          if: ->(subscription) { subscription.can_be_deactivated? }
+      end
+    end
+
+    # This method determines if a subscription may be canceled. Canceled
+    # subcriptions will not be processed. By default subscriptions may always be
+    # canceled. If this method is overriden to return false, the subscription
+    # will be moved to the :pending_cancellation state until it is canceled
+    # again and this condition is true.
+    #
+    # USE CASE: Subscriptions can only be canceled more than 10 days before they
+    # are processed. Override this method to be:
+    #
+    # def can_be_canceled?
+    #   return true if actionable_date.nil?
+    #   (actionable_date - 10.days.from_now.to_date) > 0
+    # end
+    #
+    # If a user cancels this subscription less than 10 days before it will
+    # be processed the subscription will be bumped into the
+    # :pending_cancellation state instead of being canceled. Susbcriptions
+    # pending cancellation will still be processed.
+    def can_be_canceled?
+      true
+    end
+
+    # This method determines if a subscription can be deactivated. A deactivated
+    # subscription will not be processed. By default a subscription can be
+    # deactivated if the number of max_installments defined on the
+    # subscription_line_item is equal to the number of installments associated
+    # to the subscription. In this case the subscription has been fulfilled and
+    # should not be processed again. Subscriptions without a max_installment
+    # value cannot be deactivated.
+    def can_be_deactivated?
+      return false if line_item.max_installments.nil?
+      installments.count >= line_item.max_installments
+    end
   end
 end

--- a/lib/solidus_subscriptions.rb
+++ b/lib/solidus_subscriptions.rb
@@ -1,2 +1,3 @@
 require 'solidus_core'
 require 'solidus_subscriptions/engine'
+require 'state_machines'

--- a/solidus_subscriptions.gemspec
+++ b/solidus_subscriptions.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir['test/**/*']
 
   s.add_dependency 'solidus_core', '~> 1.0'
+  s.add_dependency 'state_machines'
 
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'poltergeist'

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -5,4 +5,52 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
   it { is_expected.to belong_to :user }
   it { is_expected.to have_one :line_item }
   it { is_expected.to validate_presence_of :user }
+
+  describe '#cancel' do
+    subject { subscription.cancel }
+
+    let(:subscription) { create :subscription, :with_line_item }
+
+    context 'the subscription can be canceled' do
+      it 'is canceled' do
+        subject
+        expect(subscription.canceled?).to be_truthy
+      end
+    end
+
+    context 'the subscription cannot be canceled' do
+      before do
+        allow(subscription).to receive(:can_be_canceled?).and_return(false)
+      end
+
+      it 'is pending cancelation' do
+        subject
+        expect(subscription.pending_cancellation?).to be_truthy
+      end
+    end
+  end
+
+  describe '#deactivate' do
+    subject { subscription.deactivate }
+
+    let(:traits) { [] }
+    let(:subscription) do
+      create :subscription, :with_line_item, line_item_traits: traits
+    end
+
+    context 'the subscription can be deactivated' do
+      let(:traits) do
+        [{ max_installments: 0 }]
+      end
+
+      it 'is inactive' do
+        subject
+        expect(subscription.inactive?).to be_truthy
+      end
+    end
+
+    context 'the subscription cannot be deactivated' do
+      it { is_expected.to be_falsy }
+    end
+  end
 end


### PR DESCRIPTION
The subscription state determines the behaviours around when it is
processed. Here is a brief description of the states and how they affect
the subscription.

[active] Default state when created. Subscription can be processed
[canceled] The user has ended their subscription. Subscription will not
  be processed.
[pending_cancellation] The user has ended their subscription, but the
  conditions for canceling the subscription have not been met. Subscription
  will continue to be processed until the subscription is canceled and
  the conditions are met.
[inactive] The number of installments has been fulfilled. The subscription
  will no longer be processed