### PR TITLE
Next actionable date

### DIFF
--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -9,6 +9,12 @@ module SolidusSubscriptions
 
     validates :user, presence: :true
 
+    # The following methods are delegated to the associated
+    # SolidusSubscriptions::LineItem
+    #
+    # :interval
+    delegate :interval, to: :line_item
+
     # The subscription state determines the behaviours around when it is
     # processed. Here is a brief description of the states and how they affect
     # the subscription.
@@ -68,6 +74,16 @@ module SolidusSubscriptions
     def can_be_deactivated?
       return false if line_item.max_installments.nil?
       installments.count >= line_item.max_installments
+    end
+
+    # Get the date after the current actionable_date where this subscription
+    # will be actionable again
+    #
+    # @return [Date] The current actionable_date plus 1 interval. The next
+    #   date after the current actionable_date this subscription will be
+    #   eligible to be processed.
+    def next_actionable_date
+      actionable_date + interval.seconds
     end
   end
 end

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -85,5 +85,15 @@ module SolidusSubscriptions
     def next_actionable_date
       actionable_date + interval.seconds
     end
+
+    # Advance the actionable date to the next_actionable_date value. Will modify
+    # the record.
+    #
+    # @return [Date] The next date after the current actionable_date this
+    # subscription will be eligible to be processed.
+    def advance_actionable_date
+      update! actionable_date: next_actionable_date
+      actionable_date
+    end
   end
 end

--- a/spec/factories/line_item_factory.rb
+++ b/spec/factories/line_item_factory.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :subscription_line_item, class: 'SolidusSubscriptions::LineItem' do
     subscribable_id 1
     quantity 1
+    interval 30.days
 
     association :spree_line_item, factory: :line_item
 

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -68,4 +68,26 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
 
     it { is_expected.to eq expected_date }
   end
+
+  describe '#advance_actionable_date' do
+    subject { subscription.advance_actionable_date }
+
+    let(:expected_date) { Date.today + subscription.interval.seconds }
+    let(:subscription) do
+      build(
+        :subscription,
+        :with_line_item,
+        actionable_date: Date.today
+      )
+    end
+
+    it { is_expected.to eq expected_date }
+
+    it 'updates the subscription with the new actionable date' do
+      subject
+      expect(subscription.reload).to have_attributes(
+        actionable_date: expected_date
+      )
+    end
+  end
 end

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -53,4 +53,19 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
       it { is_expected.to be_falsy }
     end
   end
+
+  describe '#next_actionable_date' do
+    subject { subscription.next_actionable_date }
+
+    let(:expected_date) { Date.today + subscription.interval.seconds }
+    let(:subscription) do
+      build_stubbed(
+        :subscription,
+        :with_line_item,
+        actionable_date: Date.today
+      )
+    end
+
+    it { is_expected.to eq expected_date }
+  end
 end


### PR DESCRIPTION
Subscriptions know when the next time they should be processed will be. For now this will be  Current actionable date + interval.

There  may be more work to do here to synchronise multiple subscriptions for a user