### PR TITLE
Create Subscriptions::LineItems on #populate

### DIFF
--- a/app/overrides/spree/controllers/orders/create_subscription_line_items.rb
+++ b/app/overrides/spree/controllers/orders/create_subscription_line_items.rb
@@ -1,0 +1,34 @@
+# Create new subscription line items associated to the current order, when
+# a line item is added to the cart which includes subscription_line_item
+# params.
+#
+# The Subscriptions::LineItem acts as a line item place holder for a
+# Subscription, indicating that it has been added to the order, but not
+# yet purchased
+module Spree
+  module Controllers
+    module Orders
+      module CreateSubscriptionLineItems
+        def self.prepended(base)
+          base.after_action :create_subscription_line_item
+        end
+
+        private
+
+        def create_subscription_line_item
+          return unless params[:subscription_line_item]
+
+          SolidusSubscriptions::LineItem.create!(
+            subscription_params.merge(spree_line_item: line_item)
+          )
+        end
+
+        def line_item
+          @current_order.line_items.find_by(variant_id: params[:variant_id])
+        end
+      end
+    end
+  end
+end
+
+Spree::OrdersController.prepend(Spree::Controllers::Orders::CreateSubscriptionLineItems)

--- a/app/overrides/spree/controllers/orders/subscription_params.rb
+++ b/app/overrides/spree/controllers/orders/subscription_params.rb
@@ -1,3 +1,4 @@
+# Accept parameters needed to build SolidusSubscriptions::LineItem objects
 module Spree
   module Controllers
     module Orders

--- a/spec/controllers/orders/create_subscription_line_items_spec.rb
+++ b/spec/controllers/orders/create_subscription_line_items_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe Spree::Controllers::Orders::SubscriptionParams, type: :controller do
+  controller(Spree::OrdersController) {}
+  routes { Spree::Core::Engine.routes }
+
+  let!(:user) { create :user }
+
+  before do
+    allow(controller).to receive_messages(try_spree_current_user: user)
+  end
+
+  describe 'POST /orders/populate' do
+    subject { post :populate, params }
+
+    let!(:variant) { create :variant }
+    let(:params) { line_item_params }
+    let(:line_item_params) do
+      {
+        quantity: 1,
+        variant_id: variant.id
+      }
+    end
+
+    context 'with subscription_line_item params' do
+      let(:params) { line_item_params.merge(subscription_line_item_params) }
+      let(:subscription_line_item_params) do
+        {
+          subscription_line_item: {
+            quantity: 2,
+            max_installments: 3,
+            subscribable_id: variant.id,
+            interval: 30.days.to_i
+          }
+        }
+      end
+
+      it 'creates a new subscription line item' do
+        expect { subject }.
+          to change { SolidusSubscriptions::LineItem.count }.
+          from(0).to(1)
+      end
+
+      it 'creates a subscription line item with the correct values' do
+        subject
+        subscription_line_item = SolidusSubscriptions::LineItem.last
+
+        expect(subscription_line_item).to have_attributes(
+          subscription_line_item_params[:subscription_line_item]
+        )
+      end
+    end
+
+    context 'without subscription_line_item params' do
+      it { is_expected.to redirect_to cart_path }
+
+      it 'creates an order' do
+        expect { subject }.
+          to change { Spree::Order.count }.
+          from(0).to(1)
+      end
+
+      it 'creates a line item' do
+        expect { subject }.
+          to change { Spree::LineItem.count }.
+          from(0).to(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Create new subscription line items associated to the current order, when
a line item is added to the cart which includes subscription_line_item
params.

The Subscriptions::LineItem acts as a line item place holder for a
Subscription, indicating that it has been added to the order, but not
yet purchased