### PR TITLE
Subscription generator

### DIFF
--- a/app/models/solidus_subscriptions/subscription_generator.rb
+++ b/app/models/solidus_subscriptions/subscription_generator.rb
@@ -1,0 +1,18 @@
+# This module is responsible for taking SolidusSubscriptions::LineItem
+# objects and creating SolidusSubscriptions::Subscription Objects
+module SolidusSubscriptions
+  module SubscriptionGenerator
+    # Create and persist a collection of subscriptions
+    #
+    # @param [Array<SolidusSubscriptions::LineItem>] :subscription_line_items,
+    #   The subscription_line_items to be activated
+    #
+    # @return [Array<SolidusSubscriptions::Subscription>]
+    def self.activate(subscription_line_items)
+      subscription_line_items.map do |subscription_line_item|
+        user = subscription_line_item.order.user
+        Subscription.create(user: user, line_item: subscription_line_item)
+      end
+    end
+  end
+end

--- a/app/models/solidus_subscriptions/subscription_generator.rb
+++ b/app/models/solidus_subscriptions/subscription_generator.rb
@@ -11,7 +11,7 @@ module SolidusSubscriptions
     def self.activate(subscription_line_items)
       subscription_line_items.map do |subscription_line_item|
         user = subscription_line_item.order.user
-        Subscription.create(user: user, line_item: subscription_line_item)
+        Subscription.create!(user: user, line_item: subscription_line_item)
       end
     end
   end

--- a/app/overrides/spree/orders/finalize_creates_subscriptions.rb
+++ b/app/overrides/spree/orders/finalize_creates_subscriptions.rb
@@ -1,0 +1,16 @@
+# Once an order is finalized its subscriptions line items should be converted
+# into active subscritptions. This hooks into Spree::Order#finalize! and
+# passes all subscription_line_items present on the order to the Subscription
+# generator which will build and persist the subscriptions
+module Spree
+  module Orders
+    module FinalizeCreatesSubscriptions
+      def finalize!
+        SolidusSubscriptions::SubscriptionGenerator.activate(subscription_line_items)
+        super
+      end
+    end
+  end
+end
+
+Spree::Order.prepend Spree::Orders::FinalizeCreatesSubscriptions

--- a/spec/factories/spree/line_item_factory.rb
+++ b/spec/factories/spree/line_item_factory.rb
@@ -1,0 +1,17 @@
+FactoryGirl.modify do
+  factory :line_item do
+    trait :with_subscription_line_items do
+      transient do
+        n_subscription_line_items 1
+      end
+
+      subscription_line_items do
+        build_list(
+          :subscription_line_item,
+          n_subscription_line_items,
+          spree_line_item: @instance
+        )
+      end
+    end
+  end
+end

--- a/spec/factories/spree/order_factory.rb
+++ b/spec/factories/spree/order_factory.rb
@@ -1,0 +1,18 @@
+FactoryGirl.modify do
+  factory :order do
+    trait :with_subscription_line_items do
+      transient do
+        n_line_items 1
+      end
+
+      line_items do
+        build_list(
+          :line_item,
+          n_line_items,
+          :with_subscription_line_items,
+          order: @instance
+        )
+      end
+    end
+  end
+end

--- a/spec/models/solidus_subscriptions/subscription_generator_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_generator_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe SolidusSubscriptions::SubscriptionGenerator do
+  describe '.activate' do
+    subject { described_class.activate(subscription_line_items) }
+
+    let(:subscription_line_items) { build_list :subscription_line_item, 1 }
+    let(:subscription_line_item) { subscription_line_items.first }
+    let(:user) { subscription_line_items.first.order.user }
+
+    it { is_expected.to be_a Array }
+
+    it 'creates the correct number of subscritpions' do
+      expect { subject }.
+        to change { SolidusSubscriptions::Subscription.count }.
+        by(subscription_line_items.count)
+    end
+
+    it 'creates subscriptions with the correct attributes' do
+      subscription = subject.first
+      expect(subscription).to have_attributes(
+        user: user,
+        line_item: subscription_line_item
+      )
+    end
+  end
+end

--- a/spec/overrides/spree/orders/finalize_creates_subscrptions_spec.rb
+++ b/spec/overrides/spree/orders/finalize_creates_subscrptions_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Spree::Orders::FinalizeCreatesSubscriptions do
+  describe '#finalize!' do
+    subject { order.finalize! }
+    let(:order) { create :order, :with_subscription_line_items }
+
+    it 'creates new subscriptions' do
+      expect { subject }.
+        to change { SolidusSubscriptions::Subscription.count }.
+        by(order.subscription_line_items.count)
+    end
+  end
+end


### PR DESCRIPTION
Once an order is finalized its subscriptions line items should be converted
into active subscritptions. This hooks into Spree::Order#finalize! and
passes all subscription_line_items present on the order to the Subscription
generator which will build and persist the subscriptions

https://www.pivotaltracker.com/story/show/129386737