### PR TITLE
Consolidated installment

### DIFF
--- a/app/models/solidus_subscriptions/consolidated_installment.rb
+++ b/app/models/solidus_subscriptions/consolidated_installment.rb
@@ -1,0 +1,27 @@
+# This class takes a collection of installments and populates a new spree
+# order with the correct contents based on the subscriptions associated to the
+# intallments. This is to group together subscriptions being
+# processed on the same day for a specific user
+module SolidusSubscriptions
+  class ConsolidatedInstallment
+    # @return [Array<Installment>] The collection of installments to be used
+    #   when generating a new order
+    attr_reader :installments
+
+    # Get a new instance of a ConsolidatedInstallment
+    #
+    # @param [Array<Installment>] :installments, The collection of installments
+    # to be used when generating a new order
+    def initialize(installments)
+      @installments = installments
+    end
+
+    # Generate a new Spree::Order based on the information associated to the
+    # installments
+    #
+    # @return [Spree::Order]
+    def process
+      Spree::Order.new
+    end
+  end
+end

--- a/solidus_subscriptions.gemspec
+++ b/solidus_subscriptions.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'shoulda-matchers', '~> 3.1'
+  s.add_development_dependency 'rspec'
 end

--- a/spec/factories/installment_factory.rb
+++ b/spec/factories/installment_factory.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :installment, class: 'SolidusSubscriptions::Installment' do
+    association :subscription, factory: [:subscription, :with_line_item]
+  end
+end

--- a/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
+++ b/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe SolidusSubscriptions::ConsolidatedInstallment do
+  describe '#process' do
+    subject { described_class.new(installments).process }
+    let(:installments) { build_stubbed_list(:installment, 1) }
+
+    it { is_expected.to be_a Spree::Order }
+  end
+end


### PR DESCRIPTION
This class takes a collection of installments and populates a new
spree order with the correct contents based on the subscriptions associated
to the intallments. This is to group together subscriptions being
processed on the same day for a specific user

https://www.pivotaltracker.com/story/show/129392393