### PR TITLE
Subscribable LineItem and Order builder models 

### DIFF
--- a/app/models/solidus_subscriptions/line_item_builder.rb
+++ b/app/models/solidus_subscriptions/line_item_builder.rb
@@ -1,0 +1,42 @@
+# This class is responsible for taking a SubscriptionLineItem and building
+# it into a Spree::LineItem which can be added to an order
+module SolidusSubscriptions
+  class LineItemBuilder
+    attr_reader :subscription_line_item
+
+    class UnsubscribableError < StandardError
+      def initialize(subscribable)
+        @subscribable = subscribable
+        super
+      end
+
+      def to_s
+        <<-MSG.squish
+          #{@subscribable.class} with id: #{@subscribable.id} cannot be
+          subscribed to.
+        MSG
+      end
+    end
+
+    # Get a new instance of a LineItemBuilder
+    #
+    # @params [SolidusSubscriptions::LineItem] :subscription_line_item, The
+    #   subscription line item to be converted into a Spree::LineItem
+    #
+    # @return [SolidusSubscriptions::LineItemBuilder]
+    def initialize(subscription_line_item)
+      @subscription_line_item = subscription_line_item
+    end
+
+    # Get a new (unpersisted) Spree::LineItem which matches the details of
+    # :subscription_line_item
+    #
+    # @return [Spree::LineItem]
+    def line_item
+      variant = Spree::Variant.find(subscription_line_item.subscribable_id)
+      raise UnsubscribableError.new(variant) unless variant.subscribable?
+
+      Spree::LineItem.new(variant: variant, quantity: subscription_line_item.quantity)
+    end
+  end
+end

--- a/app/models/solidus_subscriptions/order_builder.rb
+++ b/app/models/solidus_subscriptions/order_builder.rb
@@ -1,0 +1,40 @@
+# This class is responsible for adding line items to order without going
+# through order contents.
+module SolidusSubscriptions
+  class OrderBuilder
+    attr_reader :order
+
+    # Get a new instance of a OrderBuilder
+    #
+    # @params [Spree::Order] :order, The order to be built
+    #
+    # @return [SolidusSubscriptions::OrderBuilder]
+    def initialize(order)
+      @order = order
+    end
+
+    # Add line items for to an order. If the order already
+    # has a line item for a given variant_id, update the quantity. Otherwise
+    # add the line item to the order.
+    #
+    # @param [Array<Spree::LineItem>] :order, the order to add the line item to
+    # @return [Spree::Order] The same order that was passed in
+    def add_line_items(*items)
+      items.each { |item| add_item_to_order(item) }
+    end
+
+    private
+
+    def add_item_to_order(new_item)
+      line_item = order.line_items.detect do |li|
+        li.variant_id == new_item.variant_id
+      end
+
+      if line_item
+        line_item.quantity += new_item.quantity
+      else
+        order.line_items << new_item
+      end
+    end
+  end
+end

--- a/spec/models/solidus_subscriptions/line_item_builder_spec.rb
+++ b/spec/models/solidus_subscriptions/line_item_builder_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe SolidusSubscriptions::LineItemBuilder do
+  let(:builder) { described_class.new subscription_line_item }
+  let!(:variant) { create(:variant, subscribable: true) }
+  let(:subscription_line_item) do
+    build_stubbed(:subscription_line_item, subscribable_id: variant.id)
+  end
+
+  describe '#line_item' do
+    subject { builder.line_item }
+    let(:expected_attributes) do
+      {
+        variant_id: subscription_line_item.subscribable_id,
+        quantity: subscription_line_item.quantity
+      }
+    end
+
+    it { is_expected.to be_a Spree::LineItem }
+    it { is_expected.to have_attributes expected_attributes }
+
+    context 'the variant is not subscribable' do
+      let!(:variant) { create(:variant) }
+
+      it 'raises an unsubscribable error' do
+        expect { subject }.to raise_error(
+          SolidusSubscriptions::LineItemBuilder::UnsubscribableError,
+          /cannot be subscribed to/
+        )
+      end
+    end
+  end
+end

--- a/spec/models/solidus_subscriptions/order_builder_spec.rb
+++ b/spec/models/solidus_subscriptions/order_builder_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe SolidusSubscriptions::OrderBuilder do
+  let(:builder) { described_class.new order }
+
+  describe '#provide_line_item!' do
+    subject { builder.add_line_items(line_item) }
+
+    let(:variant) { create :variant, subscribable: true }
+    let(:order) do
+      build_stubbed :order, line_items_attributes: line_items_attributes
+    end
+
+    let(:line_item) { create(:line_item, quantity: 4, variant: variant) }
+
+    context 'the line item doesnt already exist on the order' do
+      let(:line_items_attributes) { [] }
+
+      it 'adds a new line item to the order' do
+        expect { subject }.
+          to change { order.line_items.count }.
+          from(0).to(1)
+      end
+
+      it 'has a line item with the correct values' do
+        subject
+        line_item = order.line_items.last
+
+        expect(line_item).to have_attributes(
+          variant_id: variant.id,
+          quantity: line_item.quantity
+        )
+      end
+    end
+
+    context 'the line item already exists on the order' do
+      let(:line_items_attributes) do
+        [{
+            variant: variant,
+            quantity: 3
+        }]
+      end
+
+      it 'increases the correct line item by the correct amount' do
+        existing_line_item = order.line_items.first
+
+        expect { subject }.
+          to change { existing_line_item.quantity }.
+          by(line_item.quantity)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add SubscribableSupplier
This class is responsible for taking a SubscriptionLineItem and building
it into a Spree::LineItem which can be added to an order

Provides two methods, one which always returns a new line item for the subscribable line item and a second which will add the line item to a given order, or increment the line item quanitity if it already exists on the order. 

https://www.pivotaltracker.com/story/show/129393347