### PR TITLE
Create full orders

### DIFF
--- a/app/models/solidus_subscriptions/consolidated_installment.rb
+++ b/app/models/solidus_subscriptions/consolidated_installment.rb
@@ -8,6 +8,8 @@ module SolidusSubscriptions
     #   when generating a new order
     attr_reader :installments
 
+    delegate :user, :root_order, to: :subscription
+
     # Get a new instance of a ConsolidatedInstallment
     #
     # @param [Array<Installment>] :installments, The collection of installments
@@ -21,15 +23,31 @@ module SolidusSubscriptions
     #
     # @return [Spree::Order]
     def process
-      populate
-      order
+      ActiveRecord::Base.transaction do
+        populate
+
+        order.next! # cart => address
+
+        order.ship_address = ship_address
+        order.next! # address => delivery
+        order.next! # delivery => payment
+
+        create_payment
+        order.complete! # payment => complete
+
+        order
+      end
     end
 
     # The order fulfilling the consolidated installment
     #
     # @return [Spree::Order]
     def order
-      @order ||= Spree::Order.new
+      @order ||= Spree::Order.create(
+        user: user,
+        email: user.email,
+        store: root_order.store
+      )
     end
 
     private
@@ -41,6 +59,26 @@ module SolidusSubscriptions
 
     def order_builder
       @order_builder ||= OrderBuilder.new(order)
+    end
+
+    def subscription
+      installments.first.subscription
+    end
+
+    def ship_address
+      user.ship_address || root_order.ship_address
+    end
+
+    def active_card
+      user.credit_cards.default.last || root_order.credit_cards.last
+    end
+
+    def create_payment
+      order.payments.create(
+        source: active_card,
+        amount: order.total,
+        payment_method: Config.default_gateway
+      )
     end
   end
 end

--- a/app/models/solidus_subscriptions/consolidated_installment.rb
+++ b/app/models/solidus_subscriptions/consolidated_installment.rb
@@ -21,7 +21,26 @@ module SolidusSubscriptions
     #
     # @return [Spree::Order]
     def process
-      Spree::Order.new
+      populate
+      order
+    end
+
+    # The order fulfilling the consolidated installment
+    #
+    # @return [Spree::Order]
+    def order
+      @order ||= Spree::Order.new
+    end
+
+    private
+
+    def populate
+      line_items = installments.map { |i| i.line_item_builder.line_item }
+      order_builder.add_line_items(line_items)
+    end
+
+    def order_builder
+      @order_builder ||= OrderBuilder.new(order)
     end
   end
 end

--- a/app/models/solidus_subscriptions/installment.rb
+++ b/app/models/solidus_subscriptions/installment.rb
@@ -12,5 +12,14 @@ module SolidusSubscriptions
     )
 
     validates :subscription, presence: true
+
+    # Get the builder for the subscription_line_item. This will be an
+    # object that can generate the appropriate line item for the subscribable
+    # object
+    #
+    # @return [SolidusSubscriptions::LineItemBuilder]
+    def line_item_builder
+      LineItemBuilder.new(subscription.line_item)
+    end
   end
 end

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -6,6 +6,7 @@ module SolidusSubscriptions
     belongs_to :user, class_name: Spree.user_class
     has_one :line_item, class_name: 'SolidusSubscriptions::LineItem'
     has_many :installments, class_name: 'SolidusSubscriptions::Installment'
+    has_one :root_order, through: :line_item, class_name: 'Spree::Order', source: :order
 
     validates :user, presence: :true
 

--- a/spec/helpers/checkout_infrastructure.rb
+++ b/spec/helpers/checkout_infrastructure.rb
@@ -1,0 +1,16 @@
+# Extend your spec with this module if you want your spec to be able to move
+# an order through the checkout process
+module CheckoutInfrastructure
+  def self.extended(base)
+    base.before(:all) do
+      create :credit_card_payment_method
+      create :country
+      create :shipping_method
+    end
+
+    base.after(:all) do
+      DatabaseCleaner.clean_with(:truncation)
+      SolidusSubscriptions::Config.default_gateway = nil
+    end
+  end
+end

--- a/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
+++ b/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
@@ -1,19 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe SolidusSubscriptions::ConsolidatedInstallment do
-  # Things needed to move through the checkout smoothly
-  before do
-    create :credit_card_payment_method
-    create :country
-    create :shipping_method
-  end
-
   let(:consolidated_installment) { described_class.new(installments) }
   let(:installments) { create_list(:installment, 2) }
 
-  describe '#process' do
+  describe '#process', :checkout do
     subject(:order) { consolidated_installment.process }
-
     let(:subscription_line_item) { installments.first.subscription.line_item }
 
     it { is_expected.to be_a Spree::Order }

--- a/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
+++ b/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
@@ -1,10 +1,38 @@
 require 'rails_helper'
 
 RSpec.describe SolidusSubscriptions::ConsolidatedInstallment do
+  let(:consolidated_installment) { described_class.new(installments) }
+  let(:installments) { create_list(:installment, 2) }
+
   describe '#process' do
-    subject { described_class.new(installments).process }
-    let(:installments) { build_stubbed_list(:installment, 1) }
+    subject(:order) { consolidated_installment.process }
+
+    let(:subscription_line_item) { installments.first.subscription.line_item }
 
     it { is_expected.to be_a Spree::Order }
+
+    it 'has the correct number of line items' do
+      count = order.line_items.length
+      expect(count).to eq installments.count
+    end
+
+    it 'the line items have the correct values' do
+      line_item = order.line_items.first
+      expect(line_item).to have_attributes(
+        quantity: subscription_line_item.quantity,
+        variant_id: subscription_line_item.subscribable_id
+      )
+    end
+  end
+
+  describe '#order' do
+    subject { consolidated_installment.order }
+
+    it { is_expected.to be_a Spree::Order }
+
+    it 'is the same instance any time its called' do
+      order = consolidated_installment.order
+      expect(subject).to equal order
+    end
   end
 end

--- a/spec/models/solidus_subscriptions/installment_spec.rb
+++ b/spec/models/solidus_subscriptions/installment_spec.rb
@@ -6,4 +6,15 @@ RSpec.describe SolidusSubscriptions::Installment, type: :model do
   it { is_expected.to belong_to :subscription }
 
   it { is_expected.to validate_presence_of :subscription }
+
+  let(:installment) { build_stubbed :installment }
+
+  describe '#line_item_builder' do
+    subject { installment.line_item_builder }
+
+    let(:line_item) { installment.subscription.line_item }
+
+    it { is_expected.to be_a SolidusSubscriptions::LineItemBuilder }
+    it { is_expected.to have_attributes(subscription_line_item: line_item) }
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+Dir[File.join(File.dirname(__FILE__), 'helpers/**/*.rb')].each { |f| require f }
+
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
 
@@ -11,6 +13,8 @@ RSpec.configure do |config|
   # visit spree.admin_path
   # current_path.should eql(spree.products_path)
   config.include Spree::TestingSupport::UrlHelpers
+
+  config.extend CheckoutInfrastructure, :checkout
 
   # == Mock Framework
   #


### PR DESCRIPTION
A Consolidated installment can produce a Spree::Order with the correct
contents and move it entirely through the checkout process until it is
completed