### PR TITLE
Updated factories

### DIFF
--- a/spec/factories/installment_factory.rb
+++ b/spec/factories/installment_factory.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :installment, class: 'SolidusSubscriptions::Installment' do
-    association :subscription, factory: [:subscription, :with_line_item]
+    transient { subscription_traits [] }
+    subscription { build :subscription, :with_line_item, *subscription_traits }
   end
 end

--- a/spec/factories/line_item_factory.rb
+++ b/spec/factories/line_item_factory.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :subscription_line_item, class: 'SolidusSubscriptions::LineItem' do
-    subscribable_id 1
+    subscribable_id { create(:variant, subscribable: true).id }
     quantity 1
     interval 30.days
 

--- a/spec/factories/subscription_factory.rb
+++ b/spec/factories/subscription_factory.rb
@@ -5,7 +5,6 @@ FactoryGirl.define do
     trait :with_line_item do
       transient do
         line_item_traits []
-        test 9
       end
 
       line_item { build :subscription_line_item, *line_item_traits }

--- a/spec/factories/subscription_factory.rb
+++ b/spec/factories/subscription_factory.rb
@@ -7,7 +7,18 @@ FactoryGirl.define do
         line_item_traits []
       end
 
-      line_item { build :subscription_line_item, *line_item_traits }
+      line_item do
+        order = create(:completed_order_with_pending_payment)
+
+        # Ensure the line item traits has an associated order
+        if line_item_traits.last.is_a? Hash
+          line_item_traits.last.reverse_merge!(order: order)
+        else
+          line_item_traits << { order: order }
+        end
+
+        build :subscription_line_item, *line_item_traits
+      end
     end
   end
 end


### PR DESCRIPTION
Improve the factories 

- Remove an unneeded test value
- Actually create a subscribable object for line ites 
- Ensure subscriptions with line items have a "root order" which is completed. This is the order that initially created the subscription