### PR TITLE
Fix Terrible Order dependent spec

### DIFF
--- a/spec/lib/solidus_subscriptions/config_spec.rb
+++ b/spec/lib/solidus_subscriptions/config_spec.rb
@@ -1,11 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe SolidusSubscriptions::Config do
+  before { described_class.instance_variable_set('@gateway', nil) }
+  after { described_class.instance_variable_set('@gateway', nil) }
+
   describe '.default_gateway' do
     subject(:gateway) { described_class.default_gateway }
     let(:bogus) { build_stubbed(:credit_card_payment_method) }
-
-    before { described_class.instance_variable_set('@gateway', nil) }
 
     context 'there is a gateway set' do
       before { described_class.instance_variable_set('@gateway', bogus) }


### PR DESCRIPTION
Since the config spec changes global setting on a constant that isnt
reloaded between example, these specs alter the environment that all
other specs are running in.

It wasnt detected becuase no other specs use the default_gateway config
(yet).

Add some meta_data that will reset the default gateway value to the
initial value after running the spec.

This metadata is required on any spec that will use the default_gateway
config. Since reading this value will attempt to set a value if it can
find an appropriate gateway