### PR TITLE
Update docs and methods for consistency

### DIFF
--- a/app/models/solidus_subscriptions/order_builder.rb
+++ b/app/models/solidus_subscriptions/order_builder.rb
@@ -18,9 +18,9 @@ module SolidusSubscriptions
     # add the line item to the order.
     #
     # @param [Array<Spree::LineItem>] :order, the order to add the line item to
-    # @return [Spree::Order] The same order that was passed in
+    # @return [Array<Spree::LineItem] The collection that was passed in
     def add_line_items(*items)
-      items.each { |item| add_item_to_order(item) }
+      items.map { |item| add_item_to_order(item) }
     end
 
     private
@@ -32,6 +32,7 @@ module SolidusSubscriptions
 
       if line_item
         line_item.quantity += new_item.quantity
+        line_item
       else
         order.line_items << new_item
       end

--- a/spec/models/solidus_subscriptions/order_builder_spec.rb
+++ b/spec/models/solidus_subscriptions/order_builder_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe SolidusSubscriptions::OrderBuilder do
   let(:builder) { described_class.new order }
 
-  describe '#provide_line_item!' do
+  describe '#add_line_items' do
     subject { builder.add_line_items(line_item) }
 
     let(:variant) { create :variant, subscribable: true }


### PR DESCRIPTION
When this was changed from the supplier to the order builder, some docs
were not updated. Some of the behaviour was not consistent either.

- add_line_items returns the list of line_items present on the order
- Update docs to reflect this