### PR TITLE
Add I18n for messages intended for display

### DIFF
--- a/solidus_subscriptions.gemspec
+++ b/solidus_subscriptions.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'solidus_core', '~> 1.0'
   s.add_dependency 'state_machines'
+  s.add_dependency 'i18n'
 
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'poltergeist'


### PR DESCRIPTION
Some messages (for example installment processing messages) will be
displayed to the customer. Provide these as translations for easy
internationalization