### PR TITLE
Out of stock

### DIFF
--- a/app/models/solidus_subscriptions/consolidated_installment.rb
+++ b/app/models/solidus_subscriptions/consolidated_installment.rb
@@ -53,7 +53,26 @@ module SolidusSubscriptions
     private
 
     def populate
-      line_items = installments.map { |i| i.line_item_builder.line_item }
+      unfulfilled_installments = []
+
+      line_items = installments.map do |installment|
+        line_item = installment.line_item_builder.line_item
+
+        if line_item.nil?
+          unfulfilled_installments << installment
+          next
+        end
+
+        line_item
+      end.
+      compact
+
+      # Remove installments which had no stock from the active list
+      # They will be reprocessed later
+      @installments -= unfulfilled_installments
+      OutOfStockDispatcher.new(*unfulfilled_installments).dispatch
+
+      return if installments.empty?
       order_builder.add_line_items(line_items)
     end
 

--- a/app/models/solidus_subscriptions/consolidated_installment.rb
+++ b/app/models/solidus_subscriptions/consolidated_installment.rb
@@ -26,6 +26,10 @@ module SolidusSubscriptions
       ActiveRecord::Base.transaction do
         populate
 
+        # Installments are removed and set for future processing if they are
+        # out of stock. If there are no line items left there is nothing to do
+        return if installments.empty?
+
         order.next! # cart => address
 
         order.ship_address = ship_address

--- a/app/models/solidus_subscriptions/line_item_builder.rb
+++ b/app/models/solidus_subscriptions/line_item_builder.rb
@@ -21,6 +21,7 @@ module SolidusSubscriptions
     def line_item
       variant = Spree::Variant.find(subscription_line_item.subscribable_id)
       raise UnsubscribableError.new(variant) unless variant.subscribable?
+      return unless variant.can_supply?(subscription_line_item.quantity)
 
       Spree::LineItem.new(variant: variant, quantity: subscription_line_item.quantity)
     end

--- a/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
+++ b/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
@@ -42,6 +42,28 @@ RSpec.describe SolidusSubscriptions::ConsolidatedInstallment do
       it { is_expected.to be_complete }
     end
 
+    context 'no line items get added to the cart' do
+      before do
+        installments
+        Spree::StockItem.update_all(count_on_hand: 0, backorderable: false)
+      end
+
+      it 'creates two failed installment details' do
+        expect { order }.
+          to change { SolidusSubscriptions::InstallmentDetail.count }.
+          by(installments.length)
+
+        details = SolidusSubscriptions::InstallmentDetail.last(installments.length)
+        expect(details).to all be_failed
+      end
+
+      it { is_expected.to be_nil }
+
+      it 'creates no order' do
+        expect { subject }.to_not change { Spree::Order.count }
+      end
+    end
+
     context 'the user has addresss and active card' do
       let(:credit_card) { create(:credit_card, gateway_customer_profile_id: 'BGS-123', default: true) }
 

--- a/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
+++ b/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
@@ -74,6 +74,36 @@ RSpec.describe SolidusSubscriptions::ConsolidatedInstallment do
         expect(source).to eq consolidated_installment.root_order.payments.last.source
       end
     end
+
+    context 'the variant is out of stock' do
+      # Remove stock for 1 variant in the consolidated installment
+      before do
+        subscribable_id = installments.first.subscription.line_item.subscribable_id
+        variant = Spree::Variant.find(subscribable_id)
+        variant.stock_items.update_all(count_on_hand: 0, backorderable: false)
+      end
+
+      it 'creates an installment detail' do
+        expect { subject }.
+          to change { SolidusSubscriptions::InstallmentDetail.count }.
+          by(1)
+      end
+
+      it 'creates a failed installment detail' do
+        subject
+        detail = SolidusSubscriptions::InstallmentDetail.last
+
+        expect(detail).to_not be_successful
+        expect(detail.message).
+          to eq I18n.t('solidus_subscriptions.installment_details.out_of_stock')
+      end
+
+      it 'removes the installment from the list of installments' do
+        expect { subject }.
+          to change { consolidated_installment.installments.length }.
+          by(-1)
+      end
+    end
   end
 
   describe '#order' do

--- a/spec/models/solidus_subscriptions/line_item_builder_spec.rb
+++ b/spec/models/solidus_subscriptions/line_item_builder_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe SolidusSubscriptions::LineItemBuilder do
   let(:builder) { described_class.new subscription_line_item }
-  let!(:variant) { create(:variant, subscribable: true) }
+  let(:variant) { create(:variant, subscribable: true) }
   let(:subscription_line_item) do
     build_stubbed(:subscription_line_item, subscribable_id: variant.id)
   end
@@ -28,6 +28,11 @@ RSpec.describe SolidusSubscriptions::LineItemBuilder do
           /cannot be subscribed to/
         )
       end
+    end
+
+    context 'the variant is out of stock' do
+      before { create :stock_location, backorderable_default: false }
+      it { is_expected.to be_nil }
     end
   end
 end


### PR DESCRIPTION
If a particular line item is out of stock the consolidated order should
call the out of stock handler for the installment. This installment
should also be removed from the active installments the consolidated
installment is processing. This will avoid it having a completed order
associated to it which does not actually fulfill the failed installment