### PR TITLE
Move Unsubscribable error into its own class

### DIFF
--- a/app/models/solidus_subscriptions/line_item_builder.rb
+++ b/app/models/solidus_subscriptions/line_item_builder.rb
@@ -4,20 +4,6 @@ module SolidusSubscriptions
   class LineItemBuilder
     attr_reader :subscription_line_item
 
-    class UnsubscribableError < StandardError
-      def initialize(subscribable)
-        @subscribable = subscribable
-        super
-      end
-
-      def to_s
-        <<-MSG.squish
-          #{@subscribable.class} with id: #{@subscribable.id} cannot be
-          subscribed to.
-        MSG
-      end
-    end
-
     # Get a new instance of a LineItemBuilder
     #
     # @params [SolidusSubscriptions::LineItem] :subscription_line_item, The

--- a/app/models/solidus_subscriptions/unsubscribable_error.rb
+++ b/app/models/solidus_subscriptions/unsubscribable_error.rb
@@ -1,0 +1,17 @@
+# This error should be raised if a user attempts to subscribe to a item which
+# is not subscribable
+module SolidusSubscriptions
+  class UnsubscribableError < StandardError
+    def initialize(subscribable)
+      @subscribable = subscribable
+      super
+    end
+
+    def to_s
+      <<-MSG.squish
+        #{@subscribable.class} with id: #{@subscribable.id} cannot be
+        subscribed to.
+      MSG
+    end
+  end
+end

--- a/spec/models/solidus_subscriptions/line_item_builder_spec.rb
+++ b/spec/models/solidus_subscriptions/line_item_builder_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe SolidusSubscriptions::LineItemBuilder do
 
       it 'raises an unsubscribable error' do
         expect { subject }.to raise_error(
-          SolidusSubscriptions::LineItemBuilder::UnsubscribableError,
+          SolidusSubscriptions::UnsubscribableError,
           /cannot be subscribed to/
         )
       end


### PR DESCRIPTION
To declutter the line item builder and to have the error belong to the
SolidusSubscriptions namespace