### PR TITLE
Success handler

### DIFF
--- a/app/models/solidus_subscriptions/consolidated_installment.rb
+++ b/app/models/solidus_subscriptions/consolidated_installment.rb
@@ -39,6 +39,10 @@ module SolidusSubscriptions
         create_payment
         order.complete! # payment => complete
 
+        # Associate the order with the fulfilled installments
+        installments.each { |installment| installment.update!(order_id: order.id) }
+        SuccessDispatcher.new(installments).dispatch
+
         order
       end
     end

--- a/app/models/solidus_subscriptions/installment.rb
+++ b/app/models/solidus_subscriptions/installment.rb
@@ -35,6 +35,19 @@ module SolidusSubscriptions
       )
     end
 
+    # Mark this installment as a success
+    #
+    # @return [SolidusSubscriptions::InstallmentDetail] The record of the
+    #   successful processing attempt
+    def success!
+      update!(actionable_date: nil)
+
+      details.create!(
+        success: true,
+        message: I18n.t('solidus_subscriptions.installment_details.success')
+      )
+    end
+
     private
 
     def advance_actionable_date

--- a/app/models/solidus_subscriptions/success_dispatcher.rb
+++ b/app/models/solidus_subscriptions/success_dispatcher.rb
@@ -1,0 +1,29 @@
+# This service class is intented to provide callback behaviour to handle
+# an installment successfully being processed
+module SolidusSubscriptions
+  class SuccessDispatcher
+    attr_reader :installments
+
+    # Get a new instance of a SuccessDispatcher
+    #
+    # @param [Array<SolidusSubscriptions::Installment>] installments that
+    #   were successfully processed
+    #
+    # @return [SolidusSubscriptions::SuccessDispatcher]
+    def initialize(installments)
+      @installments = installments
+    end
+
+    # Perform successfull installment processing callbacks
+    def dispatch
+      installments.each(&:success!)
+      notify
+    end
+
+    private
+
+    def notify
+      # Tell someone the installment was sucessfully processed
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,3 +7,4 @@ en:
       out_of_stock: >
         This installment could not be processed because of insufficient
         stock.
+      success: This installment has been processed successfully!

--- a/spec/models/solidus_subscriptions/installment_spec.rb
+++ b/spec/models/solidus_subscriptions/installment_spec.rb
@@ -39,4 +39,30 @@ RSpec.describe SolidusSubscriptions::Installment, type: :model do
       expect(actionable_date).to eq expected_date
     end
   end
+
+  describe '#success!' do
+    subject { installment.success! }
+
+    let(:installment) { create :installment, actionable_date: actionable_date }
+    let(:actionable_date) { 1.month.from_now.to_date }
+
+    it 'removes any actionable date if any' do
+      expect { subject }.
+        to change { installment.actionable_date }.
+        from(actionable_date).to(nil)
+    end
+
+    it 'creates a new installment detail' do
+      expect { subject }.
+        to change { SolidusSubscriptions::InstallmentDetail.count }.
+        by(1)
+    end
+
+    it 'creates a successful installment detail' do
+      subject
+      expect(installment.details.last).to be_successful && have_attributes(
+        message: I18n.t('solidus_subscriptions.installment_details.success')
+      )
+    end
+  end
 end

--- a/spec/models/solidus_subscriptions/success_dispatcher_spec.rb
+++ b/spec/models/solidus_subscriptions/success_dispatcher_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe SolidusSubscriptions::SuccessDispatcher do
+  let(:dispatcher) { described_class.new(installments) }
+  let(:installments) { create_list(:installment, 1) }
+
+  describe 'initialization' do
+    subject { dispatcher }
+    it { is_expected.to be_a described_class }
+  end
+
+  describe '#dispatch' do
+    subject { dispatcher.dispatch }
+
+    it 'marks all the installments out of stock' do
+      expect(installments).to all receive(:success!).once
+      subject
+    end
+
+    it 'logs the failure' do
+      expect(dispatcher).to receive(:notify).once
+      subject
+    end
+  end
+end


### PR DESCRIPTION
When a subscription order is successfully completed, the success
callback handler should be run. by default it calls the success method
on all relevant installments and then runs a notifier