### PR TITLE
Scope for finding subscriptions ready for action

### DIFF
--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -16,6 +16,10 @@ module SolidusSubscriptions
     # :interval
     delegate :interval, to: :line_item
 
+    # Find all subscriptions that are "actionable"; that is, ones that have an
+    # actionable_date in the past and are not invalid or canceled.
+    scope :actionable, ->{ where("actionable_date < ?", Time.zone.now).where.not(state: ["canceled", "inactive"]) }
+
     # The subscription state determines the behaviours around when it is
     # processed. Here is a brief description of the states and how they affect
     # the subscription.

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -103,6 +103,10 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
       expect(subject).to include past_subscription
     end
 
+    it "does not include future subscriptions" do
+      expect(subject).to_not include future_subscription
+    end
+
     it "does not include inactive subscriptions" do
       expect(subject).to_not include inactive_subscription
     end

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -90,4 +90,25 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
       )
     end
   end
+
+  describe ".actionable" do
+    let!(:past_subscription) { create :subscription, actionable_date: 2.days.ago }
+    let!(:future_subscription) { create :subscription, actionable_date: 1.month.from_now }
+    let!(:inactive_subscription) { create :subscription, state: "inactive", actionable_date: 7.days.ago }
+    let!(:canceled_subscription) { create :subscription, state: "canceled", actionable_date: 4.days.ago }
+
+    subject { described_class.actionable }
+
+    it "returns subscriptions that have an actionable date in the past" do
+      expect(subject).to include past_subscription
+    end
+
+    it "does not include inactive subscriptions" do
+      expect(subject).to_not include inactive_subscription
+    end
+
+    it "does not include canceled subscriptions" do
+      expect(subject).to_not include canceled_subscription
+    end
+  end
 end


### PR DESCRIPTION
Add a scope to the Subscription model for finding all subscriptions that are
not canceled or inactive, and that have an actionable_date in the past.