### PR TITLE
Update subscription line item params

### DIFF
--- a/app/overrides/spree/controllers/orders/create_subscription_line_items.rb
+++ b/app/overrides/spree/controllers/orders/create_subscription_line_items.rb
@@ -16,7 +16,7 @@ module Spree
         private
 
         def create_subscription_line_item
-          return unless params[:subscription_line_item]
+          return unless params.fetch(:order, {})[:subscription_line_item]
 
           SolidusSubscriptions::LineItem.create!(
             subscription_params.merge(spree_line_item: line_item)

--- a/app/overrides/spree/controllers/orders/subscription_params.rb
+++ b/app/overrides/spree/controllers/orders/subscription_params.rb
@@ -6,7 +6,7 @@ module Spree
         private
 
         def subscription_params
-          params.require(:subscription_line_item).permit(
+          params.require(:order).require(:subscription_line_item).permit(
             SolidusSubscriptions::Config.subscription_line_item_attributes
           )
         end

--- a/app/overrides/spree/controllers/orders/subscription_params.rb
+++ b/app/overrides/spree/controllers/orders/subscription_params.rb
@@ -7,10 +7,7 @@ module Spree
 
         def subscription_params
           params.require(:subscription_line_item).permit(
-            :quantity,
-            :subscribable_id,
-            :interval,
-            :max_installments
+            SolidusSubscriptions::Config.subscription_line_item_attributes
           )
         end
       end

--- a/lib/solidus_subscriptions/config.rb
+++ b/lib/solidus_subscriptions/config.rb
@@ -5,6 +5,35 @@ module SolidusSubscriptions
       # retrying to fulfil it
       mattr_accessor(:reprocessing_interval) { 1.day }
 
+      # SolidusSubscriptions::LineItem attributes which are allowed to
+      # be updated from user data
+      #
+      # This is useful in the case where certain fields should not be allowed to
+      # be modified by the user. This locks these attributes from being passed
+      # in to the orders controller (or the api controller).
+
+      # Ie. if a store does not want to allow users to configure the number of
+      # installments they will receive. Add this to an initializer:
+
+      # ```
+      # SolidusSubscriptions::Config.subscription_line_item_attributes = [
+      #   :quantity,
+      #   :interval,
+      #   :subscribable_id
+      # ]
+      # ```
+
+      # This configuration also easily allows the gem to be customized to track
+      # more information on the subcriptions line items.
+      mattr_accessor(:subscription_line_item_attributes) do
+        [
+          :quantity,
+          :subscribable_id,
+          :interval,
+          :max_installments
+        ]
+      end
+
       def default_gateway=(gateway)
         @gateway = gateway
       end

--- a/spec/controllers/orders/create_subscription_line_items_spec.rb
+++ b/spec/controllers/orders/create_subscription_line_items_spec.rb
@@ -27,11 +27,13 @@ RSpec.describe Spree::Controllers::Orders::SubscriptionParams, type: :controller
       let(:params) { line_item_params.merge(subscription_line_item_params) }
       let(:subscription_line_item_params) do
         {
-          subscription_line_item: {
-            quantity: 2,
-            max_installments: 3,
-            subscribable_id: variant.id,
-            interval: 30.days.to_i
+          order: {
+            subscription_line_item: {
+              quantity: 2,
+              max_installments: 3,
+              subscribable_id: variant.id,
+              interval: 30.days.to_i
+            }
           }
         }
       end
@@ -47,7 +49,7 @@ RSpec.describe Spree::Controllers::Orders::SubscriptionParams, type: :controller
         subscription_line_item = SolidusSubscriptions::LineItem.last
 
         expect(subscription_line_item).to have_attributes(
-          subscription_line_item_params[:subscription_line_item]
+          subscription_line_item_params[:order][:subscription_line_item]
         )
       end
     end


### PR DESCRIPTION
The add to cart form nests all params under the order key. Update the
subscription line items to respect that.