### PR TITLE
Failure handler

### DIFF
--- a/app/models/solidus_subscriptions/consolidated_installment.rb
+++ b/app/models/solidus_subscriptions/consolidated_installment.rb
@@ -46,6 +46,9 @@ module SolidusSubscriptions
 
         order
       end
+    ensure
+      # Any installments that failed to be processed will be reprocessed
+      FailureDispatcher.new(installments.select(&:unfulfilled?)).dispatch
     end
 
     # The order fulfilling the consolidated installment

--- a/app/models/solidus_subscriptions/failure_dispatcher.rb
+++ b/app/models/solidus_subscriptions/failure_dispatcher.rb
@@ -1,0 +1,29 @@
+# A handler for behaviour that should happen after installments are marked as
+# failures
+module SolidusSubscriptions
+  class FailureDispatcher
+    attr_reader :installments
+
+    # Get a new instance of the FailureDispatcher
+    #
+    # @param [Array<SolidusSubscriptions::Installment>] :installments,
+    #   the installments which have failed to be fulfilled
+    #
+    # @return [SolidusSubscriptions::FailureDispatcher]
+    def initialize(installments)
+      @installments = installments
+    end
+
+    # Run after failure callback methods
+    def dispatch
+      installments.each(&:failed)
+      notify
+    end
+
+    private
+
+    def notify
+      # Tell someone stuff happened
+    end
+  end
+end

--- a/app/models/solidus_subscriptions/installment.rb
+++ b/app/models/solidus_subscriptions/installment.rb
@@ -48,6 +48,19 @@ module SolidusSubscriptions
       )
     end
 
+    # Mark this installment as a failure
+    #
+    # @return [SolidusSubscriptions::InstallmentDetail] The record of the
+    #   failed processing attempt
+    def failed
+      advance_actionable_date
+
+      details.create!(
+        success: false,
+        message: I18n.t('solidus_subscriptions.installment_details.failed')
+      )
+    end
+
     private
 
     def advance_actionable_date

--- a/app/models/solidus_subscriptions/installment.rb
+++ b/app/models/solidus_subscriptions/installment.rb
@@ -61,6 +61,13 @@ module SolidusSubscriptions
       )
     end
 
+    # Does this installment still need to be fulfilled by a completed order
+    #
+    # @return [Boolean]
+    def unfulfilled?
+      order_id.nil? || !order.completed?
+    end
+
     private
 
     def advance_actionable_date

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,3 +8,4 @@ en:
         This installment could not be processed because of insufficient
         stock.
       success: This installment has been processed successfully!
+      failed: This installment could not be processed

--- a/spec/models/solidus_subscriptions/failure_dispatcher_spec.rb
+++ b/spec/models/solidus_subscriptions/failure_dispatcher_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe SolidusSubscriptions::FailureDispatcher do
+  let(:dispatcher) { described_class.new(installments) }
+  let(:installments) { build_list(:installment, 2) }
+
+  describe '#dispatch' do
+    subject { dispatcher.dispatch }
+
+    it 'marks all the installments out of stock' do
+      expect(installments).to all receive(:failed).once
+      subject
+    end
+
+    it 'logs the failure' do
+      expect(dispatcher).to receive(:notify).once
+      subject
+    end
+  end
+end

--- a/spec/models/solidus_subscriptions/installment_spec.rb
+++ b/spec/models/solidus_subscriptions/installment_spec.rb
@@ -65,4 +65,26 @@ RSpec.describe SolidusSubscriptions::Installment, type: :model do
       )
     end
   end
+
+  describe '#failed' do
+    subject { installment.failed }
+
+    let(:expected_date) do
+      Date.today + SolidusSubscriptions::Config.reprocessing_interval
+    end
+
+    it { is_expected.to be_a SolidusSubscriptions::InstallmentDetail }
+    it { is_expected.to_not be_successful }
+    it 'has the correct message' do
+      expect(subject).to have_attributes(
+        message: I18n.t('solidus_subscriptions.installment_details.failed')
+      )
+    end
+
+    it 'advances the installment actionable_date' do
+      subject
+      actionable_date = installment.reload.actionable_date
+      expect(actionable_date).to eq expected_date
+    end
+  end
 end

--- a/spec/models/solidus_subscriptions/installment_spec.rb
+++ b/spec/models/solidus_subscriptions/installment_spec.rb
@@ -87,4 +87,19 @@ RSpec.describe SolidusSubscriptions::Installment, type: :model do
       expect(actionable_date).to eq expected_date
     end
   end
+
+  describe '#unfulfilled?' do
+    subject { installment.unfulfilled? }
+    let(:installment) { create(:installment, order: order) }
+
+    context 'the installment has an associated completed order' do
+      let(:order) { create :completed_order_with_totals }
+      it { is_expected.to be_falsy }
+    end
+
+    context 'the installment has no associated completed order' do
+      let(:order) { nil }
+      it { is_expected.to be_truthy }
+    end
+  end
 end


### PR DESCRIPTION
In order to make sure that installments are always marked for
reprocessing, ensure that even if an error is raised any installments
not associated to a completed order are marked as failed so that they
will be reprocessed in the future