### PR TITLE
Configurable subscription line item params

### DIFF
--- a/app/overrides/spree/controllers/orders/subscription_params.rb
+++ b/app/overrides/spree/controllers/orders/subscription_params.rb
@@ -7,10 +7,7 @@ module Spree
 
         def subscription_params
           params.require(:subscription_line_item).permit(
-            :quantity,
-            :subscribable_id,
-            :interval,
-            :max_installments
+            SolidusSubscriptions::Config.subscription_line_item_attributes
           )
         end
       end

--- a/lib/solidus_subscriptions/config.rb
+++ b/lib/solidus_subscriptions/config.rb
@@ -5,6 +5,35 @@ module SolidusSubscriptions
       # retrying to fulfil it
       mattr_accessor(:reprocessing_interval) { 1.day }
 
+      # SolidusSubscriptions::LineItem attributes which are allowed to
+      # be updated from user data
+      #
+      # This is useful in the case where certain fields should not be allowed to
+      # be modified by the user. This locks these attributes from being passed
+      # in to the orders controller (or the api controller).
+
+      # Ie. if a store does not want to allow users to configure the number of
+      # installments they will receive. Add this to an initializer:
+
+      # ```
+      # SolidusSubscriptions::Config.subscription_line_item_attributes = [
+      #   :quantity,
+      #   :interval,
+      #   :subscribable_id
+      # ]
+      # ```
+
+      # This configuration also easily allows the gem to be customized to track
+      # more information on the subcriptions line items.
+      mattr_accessor(:subscription_line_item_attributes) do
+        [
+          :quantity,
+          :subscribable_id,
+          :interval,
+          :max_installments
+        ]
+      end
+
       def default_gateway=(gateway)
         @gateway = gateway
       end


### PR DESCRIPTION
This is useful in the case where certain fields should not be allowed to
be modified by the user. This locks these attributes from being passed
in to the orders controller (or the api controller).

Ie if a store does not want to allow users to configure the number of
installments they will receive. Add this to an initializer:

```
SolidusSubscriptions::Config.subscription_line_item_attributes = [
  :quantity,
  :interval,
  :subscribable_id
]
```

This configuration also easily allows the gem to be customized to track
more information on the subcriptions line items if someone wanted to do
that