### PR TITLE
Api orders controller creates subscription line items

### DIFF
--- a/app/models/solidus_subscriptions/line_item.rb
+++ b/app/models/solidus_subscriptions/line_item.rb
@@ -17,7 +17,7 @@
 # [Integer] :installments How many subscription orders should be placed
 module SolidusSubscriptions
   class LineItem < ActiveRecord::Base
-    belongs_to :spree_line_item, class_name: 'Spree::LineItem'
+    belongs_to :spree_line_item, class_name: 'Spree::LineItem', inverse_of: :subscription_line_items
     has_one :order, through: :spree_line_item, class_name: 'Spree::Order'
     belongs_to(
       :subscription,

--- a/app/overrides/spree/controllers/orders/subscription_params.rb
+++ b/app/overrides/spree/controllers/orders/subscription_params.rb
@@ -16,3 +16,17 @@ module Spree
 end
 
 Spree::OrdersController.prepend(Spree::Controllers::Orders::SubscriptionParams)
+
+# Allow spree line items to accept nested attributes for subscritption line items
+line_item_attributes = Spree::PermittedAttributes.line_item_attributes
+
+subscription_line_item_attributes = {
+  subscription_line_items_attributes: [
+    SolidusSubscriptions::Config.subscription_line_item_attributes
+  ]
+}
+
+Spree::PermittedAttributes.class_variable_set(
+  '@@line_item_attributes',
+  line_item_attributes << subscription_line_item_attributes
+)

--- a/app/overrides/spree/line_items/subscription_line_items_association.rb
+++ b/app/overrides/spree/line_items/subscription_line_items_association.rb
@@ -8,8 +8,11 @@ module Spree
         base.has_many(
           :subscription_line_items,
           class_name: 'SolidusSubscriptions::LineItem',
-          foreign_key: :spree_line_item_id
+          foreign_key: :spree_line_item_id,
+          inverse_of: :spree_line_item
         )
+
+        base.accepts_nested_attributes_for :subscription_line_items
       end
     end
   end

--- a/solidus_subscriptions.gemspec
+++ b/solidus_subscriptions.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'shoulda-matchers', '~> 3.1'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rspec-activemodel-mocks'
+  s.add_development_dependency 'versioncake'
 end

--- a/solidus_subscriptions.gemspec
+++ b/solidus_subscriptions.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
   s.add_development_dependency 'shoulda-matchers', '~> 3.1'
   s.add_development_dependency 'rspec'
+  s.add_development_dependency 'rspec-activemodel-mocks'
 end

--- a/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/spec/controllers/spree/api/orders_controller_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+require 'spree/api/testing_support/helpers'
+
+RSpec.describe Spree::Api::OrdersController, type: :controller do
+  include Spree::Api::TestingSupport::Helpers
+  routes { Spree::Core::Engine.routes }
+
+  let(:order) { create :order }
+  let(:variant) { create :variant }
+
+  describe 'patch /update' do
+    subject(:subscription_line_items) do
+      patch( :update, params)
+      order.subscription_line_items(true)
+    end
+
+    before { stub_authentication! }
+
+    let(:params) do
+      {
+        order: { line_items_attributes: [line_items_params] },
+        id: order.to_param,
+        format: 'json',
+        order_token: order.guest_token
+      }
+    end
+
+    let(:line_items_params) do
+      {
+        variant_id: variant.id,
+        quantity: 1,
+        subscription_line_items_attributes: [subscription_line_items_params]
+      }
+    end
+
+    let(:subscription_line_items_params) do
+      {
+        quantity: 1,
+        subscribable_id: variant.id,
+        interval: 30.days.to_i,
+        max_installments: 12
+      }
+    end
+
+    it 'create the correct number of subscription line items' do
+      expect(subscription_line_items.length).
+        to eq line_items_params[:subscription_line_items_attributes].length
+    end
+
+    it 'creates the correct subscription line item' do
+      line_item = subscription_line_items.first
+
+      aggregate_failures do
+        expect(line_item).to have_attributes(subscription_line_items_params)
+        expect(line_item).to be_persisted
+        expect(line_item.spree_line_item).to be
+      end
+    end
+  end
+end

--- a/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/spec/controllers/spree/api/orders_controller_spec.rb
@@ -42,6 +42,11 @@ RSpec.describe Spree::Api::OrdersController, type: :controller do
       }
     end
 
+    it 'is a successful response' do
+      subject
+      expect(response).to be_successful
+    end
+
     it 'create the correct number of subscription line items' do
       expect(subscription_line_items.length).
         to eq line_items_params[:subscription_line_items_attributes].length

--- a/spec/overrides/spree/line_items/subscription_line_items_association_spec.rb
+++ b/spec/overrides/spree/line_items/subscription_line_items_association_spec.rb
@@ -3,4 +3,5 @@ require 'rails_helper'
 RSpec.describe Spree::LineItems::SubscriptionLineItemsAssociation, type: :model do
   subject { Spree::LineItem.new }
   it { is_expected.to have_many :subscription_line_items }
+  it { is_expected.to accept_nested_attributes_for :subscription_line_items }
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,6 +17,7 @@ ENV['RAILS_ENV'] = 'test'
 require File.expand_path('../dummy/config/environment.rb', __FILE__)
 
 require 'rspec/rails'
+require 'rspec/active_model/mocks'
 require 'database_cleaner'
 require 'ffaker'
 require 'pry'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,13 @@ RSpec.configure do |config|
 
   config.extend CheckoutInfrastructure, :checkout
 
+  if defined?(VersionCake::TestHelpers)
+    config.include VersionCake::TestHelpers, type: :controller
+    config.before(:each, type: :controller) do
+      set_request_version('', 1)
+    end
+  end
+
   # == Mock Framework
   #
   # If you prefer to use mocha, flexmock or RR, uncomment the appropriate line:


### PR DESCRIPTION
The api orders controller allows nested attributes for subscritpion line
ites to be posted to it when adding line items to the order. This allows
subscriptions line items to be created through the api.

JSON param example

```js
  {
    order_token: '1234'
    order: {
      line_items_attributes: [{
        // line item attributes
        subscription_line_items_attributes: [{
          quantity: 1,          // How many to include in the
          subscription orders
          max_installments: 12, // How many times to process the
          subscriptions
          interval: 2592000,    // frequency of subscription orders (in
          seconds)
          subscribable_id: 1234 // What item to include in the
          subscription order
        }]
      }]
    }
  }
```