### PR TITLE
Human-friendly intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,13 @@ To subscribe to a variant include the following parameters when posting to
   {
     // other add to cart params
     subscription_line_item: {
-      quantity: 2,           // number of units in each subscription order,
-      subscribable_id: 1234, // Which variant the subscription is for,
-      interval: 2592000      // Time between subscription orders (in seconds... because Ruby),
-      max_installments: 12   // Stop processing after this many subscription orders
-                             // (use null to process the subscription ad nauseam)
+      quantity: 2,              // number of units in each subscription order.
+      subscribable_id: 1234,    // Which variant the subscription is for.
+      interval_length: 1,       // The time between subscription activations.
+      interval_units: "months", // A plural qualifier for length.
+                                // Can be one of "days", "weeks", "months", or "years".
+      max_installments: 12      // Stop processing after this many subscription orders.
+                                // (use null to process the subscription ad nauseam)
     }
   }
 ```

--- a/app/models/solidus_subscriptions/line_item.rb
+++ b/app/models/solidus_subscriptions/line_item.rb
@@ -25,8 +25,22 @@ module SolidusSubscriptions
       inverse_of: :line_item
     )
 
+    enum interval_units: [
+      :days,
+      :weeks,
+      :months,
+      :years
+    ]
+
     validates :spree_line_item, :subscribable_id, presence: :true
-    validates :quantity, :interval, numericality: { greater_than: 0 }
+    validates :quantity, :interval_length, numericality: { greater_than: 0 }
     validates :max_installments, numericality: { greater_than: 0 }, allow_blank: true
+
+    # Calculates the number of seconds in the interval.
+    #
+    # @return [Integer] The number of seconds.
+    def interval
+      ActiveSupport::Duration.new(interval_length, { interval_units.to_sym => interval_length })
+    end
   end
 end

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -88,7 +88,7 @@ module SolidusSubscriptions
     #   date after the current actionable_date this subscription will be
     #   eligible to be processed.
     def next_actionable_date
-      actionable_date + interval.seconds
+      actionable_date + interval
     end
 
     # Advance the actionable date to the next_actionable_date value. Will modify

--- a/db/migrate/20160922164101_add_interval_length_and_units_to_subscription_line_items.rb
+++ b/db/migrate/20160922164101_add_interval_length_and_units_to_subscription_line_items.rb
@@ -1,0 +1,8 @@
+class AddIntervalLengthAndUnitsToSubscriptionLineItems < ActiveRecord::Migration
+  def change
+    add_column :solidus_subscriptions_line_items, :interval_units, :integer
+    add_column :solidus_subscriptions_line_items, :interval_length, :integer
+
+    remove_column :solidus_subscriptions_line_items, :interval
+  end
+end

--- a/lib/solidus_subscriptions/config.rb
+++ b/lib/solidus_subscriptions/config.rb
@@ -18,7 +18,8 @@ module SolidusSubscriptions
       # ```
       # SolidusSubscriptions::Config.subscription_line_item_attributes = [
       #   :quantity,
-      #   :interval,
+      #   :interval_length,
+      #   :interval_units,
       #   :subscribable_id
       # ]
       # ```
@@ -29,7 +30,8 @@ module SolidusSubscriptions
         [
           :quantity,
           :subscribable_id,
-          :interval,
+          :interval_length,
+          :interval_units,
           :max_installments
         ]
       end

--- a/lib/solidus_subscriptions/testing_support/factories/line_item_factory.rb
+++ b/lib/solidus_subscriptions/testing_support/factories/line_item_factory.rb
@@ -2,7 +2,8 @@ FactoryGirl.define do
   factory :subscription_line_item, class: 'SolidusSubscriptions::LineItem' do
     subscribable_id { create(:variant, subscribable: true).id }
     quantity 1
-    interval 30.days
+    interval_length 1
+    interval_units :months
 
     association :spree_line_item, factory: :line_item
 

--- a/solidus_subscriptions.gemspec
+++ b/solidus_subscriptions.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop-rspec', '1.4.0'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'timecop'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'shoulda-matchers', '~> 3.1'
   s.add_development_dependency 'rspec'

--- a/spec/controllers/orders/create_subscription_line_items_spec.rb
+++ b/spec/controllers/orders/create_subscription_line_items_spec.rb
@@ -32,7 +32,8 @@ RSpec.describe Spree::Controllers::Orders::SubscriptionParams, type: :controller
               quantity: 2,
               max_installments: 3,
               subscribable_id: variant.id,
-              interval: 30.days.to_i
+              interval_length: 30,
+              interval_units: "days"
             }
           }
         }

--- a/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/spec/controllers/spree/api/orders_controller_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe Spree::Api::OrdersController, type: :controller do
       {
         quantity: 1,
         subscribable_id: variant.id,
-        interval: 30.days.to_i,
+        interval_length: 30,
+        interval_units: "days",
         max_installments: 12
       }
     end

--- a/spec/models/solidus_subscriptions/line_item_spec.rb
+++ b/spec/models/solidus_subscriptions/line_item_spec.rb
@@ -9,7 +9,23 @@ RSpec.describe SolidusSubscriptions::LineItem, type: :model do
   it { is_expected.to validate_presence_of :subscribable_id }
 
   it { is_expected.to validate_numericality_of(:quantity).is_greater_than(0) }
+  it { is_expected.to validate_numericality_of(:interval_length).is_greater_than(0) }
   it { is_expected.to validate_numericality_of(:max_installments).is_greater_than(0) }
-  it { is_expected.to validate_numericality_of(:interval).is_greater_than(0) }
   it { is_expected.to validate_numericality_of(:max_installments).allow_nil }
+
+  describe "#interval" do
+    let(:line_item) { create :subscription_line_item, :with_subscription }
+    before do
+      Timecop.freeze(Date.parse("2016-09-22"))
+      line_item.subscription.update!(actionable_date: Date.today)
+    end
+    after { Timecop.return }
+
+    subject { line_item.interval }
+
+    it { is_expected.to be_a ActiveSupport::Duration }
+    it "calculates the duration correctly" do
+      expect(subject.from_now).to eq Date.parse("2016-10-22")
+    end
+  end
 end

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
   describe '#next_actionable_date' do
     subject { subscription.next_actionable_date }
 
-    let(:expected_date) { Date.today + subscription.interval.seconds }
+    let(:expected_date) { Date.today + subscription.interval }
     let(:subscription) do
       build_stubbed(
         :subscription,
@@ -72,7 +72,7 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
   describe '#advance_actionable_date' do
     subject { subscription.advance_actionable_date }
 
-    let(:expected_date) { Date.today + subscription.interval.seconds }
+    let(:expected_date) { Date.today + subscription.interval }
     let(:subscription) do
       build(
         :subscription,

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,6 +21,7 @@ require 'rspec/active_model/mocks'
 require 'database_cleaner'
 require 'ffaker'
 require 'pry'
+require 'timecop'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.


### PR DESCRIPTION
Forcing consumers of the API to calculate and provide the interval in
seconds is messy and unnecessary. Instead, we can store the interval as
length and units, and do the math ourselves. This makes the API much
easier to use and understand.