### PR TITLE
Add CanCan abilities class

### DIFF
--- a/app/controllers/solidus_subscriptions/api/v1/line_items_controller.rb
+++ b/app/controllers/solidus_subscriptions/api/v1/line_items_controller.rb
@@ -2,8 +2,7 @@ class SolidusSubscriptions::Api::V1::LineItemsController < Spree::Api::BaseContr
   before_filter :load_line_item, only: :update
 
   def update
-    return render json: {}, status: 404 unless @line_item.order.user == current_api_user
-
+    authorize! :manage, @line_item
     if @line_item.update(line_item_params)
       render json: @line_item.to_json
     else

--- a/lib/solidus_subscriptions.rb
+++ b/lib/solidus_subscriptions.rb
@@ -1,4 +1,5 @@
 require 'solidus_core'
+require "solidus_subscriptions/ability"
 require 'solidus_subscriptions/engine'
 require 'deface'
 require 'state_machines'

--- a/lib/solidus_subscriptions/ability.rb
+++ b/lib/solidus_subscriptions/ability.rb
@@ -1,0 +1,9 @@
+module SolidusSubscriptions
+  class Ability
+    include CanCan::Ability
+
+    def initialize(user)
+      can(:manage, SolidusSubscriptions::LineItem) { |li| li.order.user == user }
+    end
+  end
+end

--- a/lib/solidus_subscriptions/engine.rb
+++ b/lib/solidus_subscriptions/engine.rb
@@ -18,6 +18,8 @@ module SolidusSubscriptions
       Dir.glob(File.join(File.dirname(__FILE__), '../../app/overrides/**/*.rb')) do |c|
         Rails.configuration.cache_classes ? require(c) : load(c)
       end
+
+      Spree::Ability.register_ability(SolidusSubscriptions::Ability)
     end
 
     config.to_prepare(&method(:activate).to_proc)

--- a/spec/controllers/solidus_subscriptions/api/v1/line_items_controller_spec.rb
+++ b/spec/controllers/solidus_subscriptions/api/v1/line_items_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe SolidusSubscriptions::Api::V1::LineItemsController, type: :contro
 
     context "when the order belongs to someone else" do
       let(:order) { create :order, user: create(:user) }
-      it { is_expected.to be_not_found }
+      it { is_expected.to be_unauthorized }
     end
   end
 end


### PR DESCRIPTION
This adds a CanCan class for modelling our permissions. This then
modifies the LineItemsController to use the new CanCan abilities instead
of manually checking.