### PR TITLE
Rake task and job

### DIFF
--- a/app/jobs/solidus_subscriptions/process_installments_job.rb
+++ b/app/jobs/solidus_subscriptions/process_installments_job.rb
@@ -1,0 +1,19 @@
+# This job is responsible for creating a consolidated installment from a
+# list of installments and processing it.
+
+module SolidusSubscriptions
+  class ProcessInstallmentsJob < ActiveJob::Base
+     queue_as Config.processing_queue
+
+     # Process a collection of installments
+     #
+     # @param [Array<SolidusSubscriptions::Installment>] :installments, The
+     #   installments to be processed together and fulfilled by the same order
+     #
+     # @return [Spree::Order] The order which fulfills the list of installments
+     def perform(installments)
+       return if installments.empty?
+       ConsolidatedInstallment.new(installments).process
+     end
+  end
+end

--- a/app/models/solidus_subscriptions/installment.rb
+++ b/app/models/solidus_subscriptions/installment.rb
@@ -13,6 +13,11 @@ module SolidusSubscriptions
 
     validates :subscription, presence: true
 
+    scope :actionable, (lambda do
+      where("#{table_name}.actionable_date <= ?", Time.zone.now).
+        where(order_id: nil)
+    end)
+
     # Get the builder for the subscription_line_item. This will be an
     # object that can generate the appropriate line item for the subscribable
     # object

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -18,7 +18,10 @@ module SolidusSubscriptions
 
     # Find all subscriptions that are "actionable"; that is, ones that have an
     # actionable_date in the past and are not invalid or canceled.
-    scope :actionable, ->{ where("actionable_date < ?", Time.zone.now).where.not(state: ["canceled", "inactive"]) }
+    scope :actionable, (lambda do
+      where("#{table_name}.actionable_date < ?", Time.zone.now).
+        where.not(state: ["canceled", "inactive"])
+    end)
 
     # The subscription state determines the behaviours around when it is
     # processed. Here is a brief description of the states and how they affect

--- a/lib/solidus_subscriptions/config.rb
+++ b/lib/solidus_subscriptions/config.rb
@@ -5,6 +5,9 @@ module SolidusSubscriptions
       # retrying to fulfil it
       mattr_accessor(:reprocessing_interval) { 1.day }
 
+      # Which queue is responsible for processing subscriptions
+      mattr_accessor(:processing_queue) { :default }
+
       # SolidusSubscriptions::LineItem attributes which are allowed to
       # be updated from user data
       #

--- a/lib/solidus_subscriptions/engine.rb
+++ b/lib/solidus_subscriptions/engine.rb
@@ -10,6 +10,8 @@ module SolidusSubscriptions
       g.test_framework :rspec
     end
 
+    config.autoload_paths << config.root.join('app', 'jobs')
+
     initializer 'solidus_subscriptions.configs', before: "spree.register.payment_methods" do
       require 'solidus_subscriptions/config'
     end

--- a/lib/solidus_subscriptions/engine.rb
+++ b/lib/solidus_subscriptions/engine.rb
@@ -11,6 +11,7 @@ module SolidusSubscriptions
     end
 
     config.autoload_paths << config.root.join('app', 'jobs')
+    config.autoload_paths << config.root.join('lib')
 
     initializer 'solidus_subscriptions.configs', before: "spree.register.payment_methods" do
       require 'solidus_subscriptions/config'

--- a/lib/solidus_subscriptions/processor.rb
+++ b/lib/solidus_subscriptions/processor.rb
@@ -1,0 +1,90 @@
+# This class is responsible for finding subscriptions and installments
+# which need to be processed. It will group them together by user and attempts
+# to process them together.
+#
+# This class passes the reponsibility of actually creating the order off onto
+# the consolidated installment class.
+#
+# This class generates `ProcessInstallmentsJob`s
+module SolidusSubscriptions
+  class Processor
+    class << self
+      # Find all actionable subscriptions and intallments, group them together
+      # by user, and schedule a processing job for the group as a batch
+      def run
+        batched_users_to_be_processed.each { |batch| new(batch).build_jobs }
+      end
+
+      private
+
+      def batched_users_to_be_processed
+        subscriptions = Subscription.arel_table
+        installments = Installment.arel_table
+
+        Spree::User.
+          joins(:subscriptions).
+          joins(
+            subscriptions.
+              join(installments, Arel::Nodes::OuterJoin).
+              on(subscriptions[:id].eq(installments[:subscription_id])).
+              join_sources
+          ).
+          where(
+            Subscription.actionable.arel.constraints.reduce(:and).
+              or(Installment.actionable.arel.constraints.reduce(:and))
+          ).
+          distinct.
+          find_in_batches
+      end
+    end
+
+    # @return [Array<Spree.user_class>]
+    attr_reader :users
+
+    # Get a new instance of the SolidusSubscriptions::Processor
+    #
+    # @param users [Array<Spree.user_class>] A list of users with actionable
+    #   subscriptions or installments
+    #
+    # @return [SolidusSubscriptions::Processor]
+    def initialize(users)
+      @users = users
+      @installments = {}
+    end
+
+    # Create `ProcessInstallmentsJob`s for the users used to initalize the
+    # instance
+    def build_jobs
+      users.map { |user| ProcessInstallmentsJob.perform_later installments(user) }
+    end
+
+    private
+
+    def subscriptions_by_id
+      @subscriptions_by_id ||= Subscription.
+        actionable.
+        where(user_id: user_ids).
+        group_by(&:user_id)
+    end
+
+    def retry_installments
+      @failed_installments ||= Installment.
+        actionable.
+        includes(:subscription).
+        where(solidus_subscriptions_subscriptions: { user_id: user_ids }).
+        group_by { |i| i.subscription.user_id }
+    end
+
+    def installments(user)
+      @installments[user.id] ||= retry_installments.fetch(user.id, []) + new_installments(user)
+    end
+
+    def new_installments(user)
+      subscriptions_by_id.fetch(user.id, []).map { |sub| sub.installments.create! }
+    end
+
+    def user_ids
+      @user_ids ||= users.map(&:id)
+    end
+  end
+end

--- a/lib/solidus_subscriptions/testing_support/factories/installment_detail_factory.rb
+++ b/lib/solidus_subscriptions/testing_support/factories/installment_detail_factory.rb
@@ -1,5 +1,7 @@
 FactoryGirl.define do
   factory :installment_detail, class: 'SolidusSubscriptions::InstallmentDetail' do
     installment
+
+    trait(:success) { success true }
   end
 end

--- a/lib/solidus_subscriptions/testing_support/factories/installment_factory.rb
+++ b/lib/solidus_subscriptions/testing_support/factories/installment_factory.rb
@@ -2,5 +2,15 @@ FactoryGirl.define do
   factory :installment, class: 'SolidusSubscriptions::Installment' do
     transient { subscription_traits [] }
     subscription { build :subscription, :with_line_item, *subscription_traits }
+
+    trait :failed do
+      actionable_date { Time.zone.yesterday }
+      details { build_list(:installment_detail, 1, installment: @instance) }
+    end
+
+    trait :success do
+      association :order, factory: :completed_order_with_totals
+      details { build_list(:installment_detail, 1, :success, installment: @instance) }
+    end
   end
 end

--- a/lib/solidus_subscriptions/testing_support/factories/subscription_factory.rb
+++ b/lib/solidus_subscriptions/testing_support/factories/subscription_factory.rb
@@ -1,6 +1,9 @@
 FactoryGirl.define do
   factory :subscription, class: 'SolidusSubscriptions::Subscription' do
-    user
+    user do
+      ccs = build_list(:credit_card, 1, gateway_customer_profile_id: 'BGS-123', default: true)
+      build :user, credit_cards: ccs
+    end
 
     trait :with_line_item do
       transient do
@@ -9,5 +12,18 @@ FactoryGirl.define do
 
       line_item { build :subscription_line_item, *line_item_traits }
     end
+
+    trait :actionable do
+      with_line_item
+      actionable_date { Time.zone.now.yesterday }
+    end
+
+    trait :not_actionable do
+      with_line_item
+      actionable_date { Time.zone.now.tomorrow }
+    end
+
+    trait(:canceled) { state 'canceled' }
+    trait(:inactive) { state 'inactive' }
   end
 end

--- a/lib/tasks/process_subscriptions.rake
+++ b/lib/tasks/process_subscriptions.rake
@@ -1,0 +1,6 @@
+namespace :solidus_subscriptions do
+  desc 'Create orders for actionable subscriptions'
+  task process: :environment do
+    SoliudusSubscriptions::Processor.run
+  end
+end

--- a/spec/jobs/solidus_subscriptions/process_installments_job_spec.rb
+++ b/spec/jobs/solidus_subscriptions/process_installments_job_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe SolidusSubscriptions::ProcessInstallmentsJob do
+  let(:root_order) { create :completed_order_with_pending_payment }
+  let(:installments) do
+    traits = {
+      subscription_traits: [{
+        line_item_traits: [{
+          spree_line_item: root_order.line_items.first
+        }]
+      }]
+    }
+
+    create_list(:installment, 2, traits)
+  end
+
+  describe '#perform' do
+    subject { described_class.new.perform(installments) }
+
+    it 'processes the consolidated installment' do
+      expect_any_instance_of(SolidusSubscriptions::ConsolidatedInstallment).
+        to receive(:process).once
+
+      subject
+    end
+  end
+end

--- a/spec/lib/solidus_subscriptions/processor_spec.rb
+++ b/spec/lib/solidus_subscriptions/processor_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe SolidusSubscriptions::Processor, :checkout do
+  let(:user) do
+    ccs = build_list(:credit_card, 1, gateway_customer_profile_id: 'BGS-123', default: true)
+    build :user, credit_cards: ccs
+  end
+
+  let!(:actionable_subscriptions) { create_list(:subscription, 2, :actionable, user: user) }
+  let!(:future_subscriptions) { create_list(:subscription, 2, :not_actionable) }
+  let!(:canceled_subscriptions) { create_list(:subscription, 2, :canceled) }
+  let!(:inactive) { create_list(:subscription, 2, :inactive) }
+
+  let!(:successful_installments) { create_list :installment, 2, :success }
+  let!(:failed_installments) do
+    create_list(
+      :installment,
+      2,
+      :failed,
+      subscription_traits: [{ user: user }]
+    )
+  end
+
+  # all subscriptions and previously failed installments belong to the same user
+  let(:expected_orders) { 1 }
+
+  shared_examples 'a subscription order' do
+    let(:order_variant_ids) { Spree::Order.last.variant_ids }
+    let(:expected_ids) do
+      subs_ids = actionable_subscriptions.map { |s| s.line_item.subscribable_id }
+      inst_ids = failed_installments.map { |i| i.subscription.line_item.subscribable_id }
+
+      subs_ids + inst_ids
+    end
+
+    it 'creates the correct number of orders' do
+      expect { subject }.to change { Spree::Order.complete.count }.by expected_orders
+    end
+
+    it 'creates the correct order' do
+      subject
+      expect(order_variant_ids).to match_array expected_ids
+    end
+  end
+
+  describe '.run' do
+    subject { described_class.run }
+
+    it_behaves_like 'a subscription order'
+  end
+
+  describe '#build_jobs' do
+    subject { described_class.new([user]).build_jobs }
+    it_behaves_like 'a subscription order'
+  end
+end

--- a/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
+++ b/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
@@ -3,9 +3,11 @@ require 'rails_helper'
 RSpec.describe SolidusSubscriptions::ConsolidatedInstallment do
   let(:consolidated_installment) { described_class.new(installments) }
   let(:root_order) { create :completed_order_with_pending_payment }
+  let(:subscription_user) { create :user }
   let(:installments) do
     traits = {
       subscription_traits: [{
+        user: subscription_user,
         line_item_traits: [{
           spree_line_item: root_order.line_items.first
         }]


### PR DESCRIPTION
Actionable subscriptions and installments can now be processed with the
rake task:

`bundle exec rake solidus_subscriptions:process`