### PR TITLE
Fix after action to create subs line items

### DIFF
--- a/app/overrides/spree/controllers/orders/create_subscription_line_items.rb
+++ b/app/overrides/spree/controllers/orders/create_subscription_line_items.rb
@@ -10,14 +10,16 @@ module Spree
     module Orders
       module CreateSubscriptionLineItems
         def self.prepended(base)
-          base.after_action :create_subscription_line_item
+          base.after_action(
+            :create_subscription_line_item,
+            only: :populate,
+            if: ->{ params[:subscription_line_item] }
+          )
         end
 
         private
 
         def create_subscription_line_item
-          return unless params.fetch(:order, {})[:subscription_line_item]
-
           SolidusSubscriptions::LineItem.create!(
             subscription_params.merge(spree_line_item: line_item)
           )

--- a/app/overrides/spree/controllers/orders/subscription_params.rb
+++ b/app/overrides/spree/controllers/orders/subscription_params.rb
@@ -6,7 +6,7 @@ module Spree
         private
 
         def subscription_params
-          params.require(:order).require(:subscription_line_item).permit(
+          params.require(:subscription_line_item).permit(
             SolidusSubscriptions::Config.subscription_line_item_attributes
           )
         end

--- a/spec/controllers/orders/create_subscription_line_items_spec.rb
+++ b/spec/controllers/orders/create_subscription_line_items_spec.rb
@@ -27,14 +27,12 @@ RSpec.describe Spree::Controllers::Orders::SubscriptionParams, type: :controller
       let(:params) { line_item_params.merge(subscription_line_item_params) }
       let(:subscription_line_item_params) do
         {
-          order: {
-            subscription_line_item: {
-              quantity: 2,
-              max_installments: 3,
-              subscribable_id: variant.id,
-              interval_length: 30,
-              interval_units: "days"
-            }
+          subscription_line_item: {
+            quantity: 2,
+            max_installments: 3,
+            subscribable_id: variant.id,
+            interval_length: 30,
+            interval_units: "days"
           }
         }
       end
@@ -50,7 +48,7 @@ RSpec.describe Spree::Controllers::Orders::SubscriptionParams, type: :controller
         subscription_line_item = SolidusSubscriptions::LineItem.last
 
         expect(subscription_line_item).to have_attributes(
-          subscription_line_item_params[:order][:subscription_line_item]
+          subscription_line_item_params[:subscription_line_item]
         )
       end
     end


### PR DESCRIPTION
Restrict the after_action which adds subscription line items to the cart
to the :populate action of the Spree::OrdersController.

Only run this action if there are the correct parameters for it

Cart params are not nested under order