### PR TITLE
Update subscriptions

### DIFF
--- a/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
+++ b/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
@@ -1,5 +1,13 @@
 class SolidusSubscriptions::Api::V1::SubscriptionsController < Spree::Api::BaseController
-  before_filter :load_subscription, only: :cancel
+  before_filter :load_subscription, only: [:cancel, :update]
+
+  def update
+    if @subscription.update(subscription_params)
+      render json: @subscription.to_json(include: :line_item)
+    else
+      render json: @subscription.errors.to_json, status: 422
+    end
+  end
 
   def cancel
     if @subscription.cancel
@@ -13,5 +21,15 @@ class SolidusSubscriptions::Api::V1::SubscriptionsController < Spree::Api::BaseC
 
   def load_subscription
     @subscription = current_api_user.subscriptions.find(params[:id])
+  end
+
+  def subscription_params
+    params.require(:subscription).permit(
+      line_item_attributes: line_item_attributes
+    )
+  end
+
+  def line_item_attributes
+    SolidusSubscriptions::Config.subscription_line_item_attributes - [:subscribable_id] + [:id]
   end
 end

--- a/app/decorators/spree/controllers/orders/subscription_params.rb
+++ b/app/decorators/spree/controllers/orders/subscription_params.rb
@@ -21,9 +21,7 @@ Spree::OrdersController.prepend(Spree::Controllers::Orders::SubscriptionParams)
 line_item_attributes = Spree::PermittedAttributes.line_item_attributes
 
 subscription_line_item_attributes = {
-  subscription_line_items_attributes: [
-    SolidusSubscriptions::Config.subscription_line_item_attributes
-  ]
+  subscription_line_items_attributes: SolidusSubscriptions::Config.subscription_line_item_attributes
 }
 
 Spree::PermittedAttributes.class_variable_set(

--- a/app/decorators/spree/users/have_many_subscriptions.rb
+++ b/app/decorators/spree/users/have_many_subscriptions.rb
@@ -8,9 +8,24 @@ module Spree
           class_name: 'SolidusSubscriptions::Subscription',
           foreign_key: 'user_id'
         )
+
+        base.accepts_nested_attributes_for :subscriptions
       end
     end
   end
 end
 
 Spree.user_class.prepend(Spree::Users::HaveManySubscritptions)
+
+user_attributes = Spree::PermittedAttributes.user_attributes
+
+subscription_attributes = {
+  subscriptions_attributes: {
+    line_item_attributes: SolidusSubscriptions::Config.subscription_line_item_attributes
+  }
+}
+
+Spree::PermittedAttributes.class_variable_set(
+  '@@user_attributes',
+  user_attributes << subscription_attributes
+)

--- a/app/decorators/spree/users/have_many_subscriptions.rb
+++ b/app/decorators/spree/users/have_many_subscriptions.rb
@@ -20,9 +20,10 @@ Spree.user_class.prepend(Spree::Users::HaveManySubscritptions)
 user_attributes = Spree::PermittedAttributes.user_attributes
 
 subscription_attributes = {
-  subscriptions_attributes: {
-    line_item_attributes: SolidusSubscriptions::Config.subscription_line_item_attributes
-  }
+  subscriptions_attributes: [
+    :id,
+    { line_item_attributes: SolidusSubscriptions::Config.subscription_line_item_attributes + [:id] }
+  ]
 }
 
 Spree::PermittedAttributes.class_variable_set(

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -13,8 +13,8 @@ module SolidusSubscriptions
     # The following methods are delegated to the associated
     # SolidusSubscriptions::LineItem
     #
-    # :interval
-    delegate :interval, to: :line_item
+    # :interval, :quantity, :subscribable_id, :max_installments
+    delegate :interval, :quantity, :subscribable_id, :max_installments, to: :line_item
 
     # Find all subscriptions that are "actionable"; that is, ones that have an
     # actionable_date in the past and are not invalid or canceled.

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -10,6 +10,8 @@ module SolidusSubscriptions
 
     validates :user, presence: :true
 
+    accepts_nested_attributes_for :line_item
+
     # The following methods are delegated to the associated
     # SolidusSubscriptions::LineItem
     #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ SolidusSubscriptions::Engine.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :line_items, only: [:update, :destroy]
-      resources :subscriptions, only: [] do
+      resources :subscriptions, only: [:update] do
         member do
           post :cancel
         end

--- a/docs/api/v1/subscriptions.md
+++ b/docs/api/v1/subscriptions.md
@@ -10,6 +10,7 @@ actionable date to prevent further processing.
 
 ```json
 {
+  "token": "userapitoken",
   "id": 1
 }
 ```
@@ -27,4 +28,50 @@ HTTP/1.1 200 OK
   "created_at": "2016-09-26T16:40:37.660Z",
   "updated_at": "2016-09-26T16:43:55.330Z"
 }
+```
+
+## PATCH `/api/v1/subscriptions/:id`
+*Authentication Required*
+
+Make changes to the Subscription object or the subscription line item object
+
+### Example params
+
+```json
+{
+  "token": "userapitoken",
+  "id": 1,
+  "line_item_attributes": {
+    "quantity": 5,
+    "interval_length": 1,
+    "interval_units": "months"
+  }
+}
+```
+
+## Example response
+```
+HTTP/1.1 200 OK
+
+{
+  "id": 1,
+  "actionable_date": nil,
+  "state": "active",
+  "user_id": 1,
+  "created_at": "2016-09-26T23:50:32.923Z",
+  "updated_at": "2016-09-26T23:50:32.923Z",
+  "line_item": {
+    "id": 1,
+    "spree_line_item_id": 1,
+    "subscription_id": 1,
+    "quantity": 5,
+    "max_installments": nil,
+    "subscribable_id": 2,
+    "created_at": "2016-09-26T23:50:32.923Z",
+    "updated_at": "2016-09-26T23:51:05.784Z",
+    "interval_units": "months",
+    "interval_length": 1
+   }
+ }
+
 ```

--- a/spec/controllers/solidus_subscriptions/api/v1/subscriptions_controller_spec.rb
+++ b/spec/controllers/solidus_subscriptions/api/v1/subscriptions_controller_spec.rb
@@ -20,4 +20,47 @@ RSpec.describe SolidusSubscriptions::Api::V1::SubscriptionsController, type: :co
       it { is_expected.to be_not_found }
     end
   end
+
+  describe 'PATCH :update' do
+    subject { patch :update, params }
+    let(:params) do
+      {
+        id: subscription.id,
+        token: user.spree_api_key,
+        subscription: subscription_params
+      }
+    end
+
+    let(:subscription_params) do
+      {
+        line_item_attributes: {
+          id: subscription.line_item.id,
+          quantity: 6
+        }
+      }
+    end
+
+    context 'when the subscription belongs to the user' do
+      let!(:subscription) { create :subscription, :with_line_item, user: user }
+      it { is_expected.to be_success }
+
+      context 'when the params are not valid' do
+        let(:subscription_params) do
+          {
+            line_item_attributes: {
+              id: subscription.line_item.id,
+              quantity: -6
+            }
+          }
+        end
+
+        it { is_expected.to have_http_status(:unprocessable_entity) }
+      end
+    end
+
+    context 'when the subscription belongs to someone else' do
+      let!(:subscription) { create :subscription, :with_line_item, user: create(:user) }
+      it { is_expected.to be_not_found }
+    end
+  end
 end

--- a/spec/controllers/spree/api/users_controller_spec.rb
+++ b/spec/controllers/spree/api/users_controller_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+require 'spree/api/testing_support/helpers'
+
+RSpec.describe Spree::Api::UsersController, type: :controller do
+  include Spree::Api::TestingSupport::Helpers
+  routes { Spree::Core::Engine.routes }
+
+  let!(:user) do
+    create(:user) { |user| user.generate_spree_api_key }.tap(&:save)
+  end
+  let!(:subscription) { create :subscription, :with_line_item, user: user }
+
+  describe 'patch /update' do
+    subject { patch :update, params }
+
+    let(:params) do
+      {
+        id: user.id,
+        token: user.spree_api_key,
+        format: 'json',
+        user: {
+          subscriptions_attributes: [{
+            id: subscription.id,
+            line_item_attributes: line_item_attributes
+          }]
+        }
+      }
+    end
+
+    let(:line_item_attributes) do
+      {
+        id: subscription.line_item.id,
+        quantity: 6,
+        interval_length: 1,
+        interval_units: 'months'
+      }
+    end
+
+    it 'updates the subscription line items' do
+      subject
+      line_item = subscription.line_item(true)
+
+      expect(line_item).to have_attributes(line_item_attributes)
+    end
+  end
+end

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
   it { is_expected.to have_one :line_item }
   it { is_expected.to validate_presence_of :user }
 
+  it { is_expected.to accept_nested_attributes_for :line_item }
+
   describe '#cancel' do
     subject { subscription.cancel }
 
@@ -35,12 +37,14 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
 
     let(:traits) { [] }
     let(:subscription) do
-      create :subscription, :with_line_item, line_item_traits: traits
+      create :subscription, :with_line_item, line_item_traits: traits do |s|
+        s.installments = build_list(:installment, 2)
+      end
     end
 
     context 'the subscription can be deactivated' do
       let(:traits) do
-        [{ max_installments: 0 }]
+        [{ max_installments: 1 }]
       end
 
       it 'is inactive' do

--- a/spec/overrides/spree/users/have_many_subscriptions.rb
+++ b/spec/overrides/spree/users/have_many_subscriptions.rb
@@ -4,4 +4,5 @@ RSpec.describe Spree::Users::HaveManySubscritptions, type: :model do
   subject { Spree::User.new }
 
   it { is_expected.to have_many :subscriptions }
+  it { is_expected.to accept_nested_attributes_for :subscriptions }
 end


### PR DESCRIPTION
Allow subscriptions to be updated through the Users api controller.

This requires subscriptions accepting nested attributes for subscription line items, and users to accept nested attributes for subscriptions. 

Subscriptions can be updated though users with the following params: 
```json
{
  "id": "1",
  "token": "677a63de81a19a27eae30f417092635a53279d94a21949d5", 
  "user": {
    "subscriptions_attributes": [{
      "id": 1, 
      "line_item_attributes": {
         "id": 1, 
         "quantity": 6, 
         "interval_length": 1, 
         "interval_units": "months"
        }
      }
   ]}
}
```