### PR TITLE
Line items dependent destroy subs line items

### DIFF
--- a/app/decorators/spree/line_items/subscription_line_items_association.rb
+++ b/app/decorators/spree/line_items/subscription_line_items_association.rb
@@ -9,7 +9,8 @@ module Spree
           :subscription_line_items,
           class_name: 'SolidusSubscriptions::LineItem',
           foreign_key: :spree_line_item_id,
-          inverse_of: :spree_line_item
+          inverse_of: :spree_line_item,
+          dependent: :destroy
         )
 
         base.accepts_nested_attributes_for :subscription_line_items


### PR DESCRIPTION
If a line item is destroyed, the associated subscription_line_items
should also get blown away. No subscription line item is permitted to
exist independently of a line item. The subscription needed to be
"ordered" somehow