### PR TITLE
Use canonical model name for params namespace

### DIFF
--- a/app/controllers/solidus_subscriptions/api/v1/line_items_controller.rb
+++ b/app/controllers/solidus_subscriptions/api/v1/line_items_controller.rb
@@ -1,5 +1,6 @@
 class SolidusSubscriptions::Api::V1::LineItemsController < Spree::Api::BaseController
   before_filter :load_line_item, only: [:update, :destroy]
+  wrap_parameters :subscription_line_item
 
   def update
     authorize! :manage, @line_item


### PR DESCRIPTION
`:subscription_line_item` does not match the controller's model name,
which is inconsistent and causes problems for people using things like
Backbone model serialisation.