### PR TITLE
Subs line item name

### DIFF
--- a/app/models/solidus_subscriptions/installment.rb
+++ b/app/models/solidus_subscriptions/installment.rb
@@ -19,7 +19,7 @@ module SolidusSubscriptions
     #
     # @return [SolidusSubscriptions::LineItemBuilder]
     def line_item_builder
-      LineItemBuilder.new(subscription.line_item)
+      subscription.line_item_builder
     end
 
     # Mark this installment as out of stock.

--- a/app/models/solidus_subscriptions/line_item.rb
+++ b/app/models/solidus_subscriptions/line_item.rb
@@ -54,6 +54,10 @@ module SolidusSubscriptions
       dummy_line_item.price
     end
 
+    def next_actionable_date
+      dummy_subscription.next_actionable_date
+    end
+
     private
 
     # Get a placeholder line item for calculating the values of future

--- a/app/models/solidus_subscriptions/line_item.rb
+++ b/app/models/solidus_subscriptions/line_item.rb
@@ -61,25 +61,26 @@ module SolidusSubscriptions
     private
 
     # Get a placeholder line item for calculating the values of future
-    # subscription orders. It associates to a frozen order and cannot be saved
+    # subscription orders. It is frozen and cannot be saved
     def dummy_line_item
-      @dummy_line_item ||= dummy_subscription.line_item_builder.line_item.tap do |li|
+      dummy_subscription.line_item_builder.line_item.tap do |li|
         li.order = dummy_order
         li.validate
-      end
+      end.
+      freeze
     end
 
     # Get a placeholder order for calculating the values of future
     # subscription orders. It is a frozen duplicate of the current order and
     # cannot be saved
     def dummy_order
-      @dummy_order ||= spree_line_item.order.dup.freeze
+      spree_line_item.order.dup.freeze
     end
 
     # A place holder for calculating dynamic values needed to display in the cart
     # it is frozen and cannot be saved
     def dummy_subscription
-      @dummy_subscritpion ||= Subscription.new(line_item: self).freeze
+      Subscription.new(line_item: self).freeze
     end
   end
 end

--- a/app/models/solidus_subscriptions/line_item.rb
+++ b/app/models/solidus_subscriptions/line_item.rb
@@ -50,12 +50,26 @@ module SolidusSubscriptions
       dummy_line_item.name
     end
 
+    def price
+      dummy_line_item.price
+    end
+
     private
 
     # Get a placeholder line item for calculating the values of future
     # subscription orders. It associates to a frozen order and cannot be saved
     def dummy_line_item
-      @dummy_line_item ||= dummy_subscription.line_item_builder.line_item
+      @dummy_line_item ||= dummy_subscription.line_item_builder.line_item.tap do |li|
+        li.order = dummy_order
+        li.validate
+      end
+    end
+
+    # Get a placeholder order for calculating the values of future
+    # subscription orders. It is a frozen duplicate of the current order and
+    # cannot be saved
+    def dummy_order
+      @dummy_order ||= spree_line_item.order.dup.freeze
     end
 
     # A place holder for calculating dynamic values needed to display in the cart

--- a/app/models/solidus_subscriptions/line_item.rb
+++ b/app/models/solidus_subscriptions/line_item.rb
@@ -42,5 +42,12 @@ module SolidusSubscriptions
     def interval
       ActiveSupport::Duration.new(interval_length, { interval_units.to_sym => interval_length })
     end
+
+    # The name of the variant which will eventually fulfill this line item
+    #
+    # @return [String]
+    def name
+      build_subscription.line_item_builder.line_item.name
+    end
   end
 end

--- a/app/models/solidus_subscriptions/line_item.rb
+++ b/app/models/solidus_subscriptions/line_item.rb
@@ -58,6 +58,11 @@ module SolidusSubscriptions
       dummy_subscription.next_actionable_date
     end
 
+    def as_json(**options)
+      options[:methods] ||= [:price, :next_actionable_date, :name]
+      super(options)
+    end
+
     private
 
     # Get a placeholder line item for calculating the values of future
@@ -80,7 +85,7 @@ module SolidusSubscriptions
     # A place holder for calculating dynamic values needed to display in the cart
     # it is frozen and cannot be saved
     def dummy_subscription
-      Subscription.new(line_item: self).freeze
+      Subscription.new(line_item: dup).freeze
     end
   end
 end

--- a/app/models/solidus_subscriptions/line_item.rb
+++ b/app/models/solidus_subscriptions/line_item.rb
@@ -47,7 +47,21 @@ module SolidusSubscriptions
     #
     # @return [String]
     def name
-      build_subscription.line_item_builder.line_item.name
+      dummy_line_item.name
+    end
+
+    private
+
+    # Get a placeholder line item for calculating the values of future
+    # subscription orders. It associates to a frozen order and cannot be saved
+    def dummy_line_item
+      @dummy_line_item ||= dummy_subscription.line_item_builder.line_item
+    end
+
+    # A place holder for calculating dynamic values needed to display in the cart
+    # it is frozen and cannot be saved
+    def dummy_subscription
+      @dummy_subscritpion ||= Subscription.new(line_item: self).freeze
     end
   end
 end

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -109,5 +109,14 @@ module SolidusSubscriptions
     def unset_actionable_date!
       update!(actionable_date: nil)
     end
+
+    # Get the builder for the subscription_line_item. This will be an
+    # object that can generate the appropriate line item for the subscribable
+    # object
+    #
+    # @return [SolidusSubscriptions::LineItemBuilder]
+    def line_item_builder
+      LineItemBuilder.new(line_item)
+    end
   end
 end

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -90,7 +90,7 @@ module SolidusSubscriptions
     #   date after the current actionable_date this subscription will be
     #   eligible to be processed.
     def next_actionable_date
-      actionable_date + interval
+      (actionable_date || Time.zone.now) + interval
     end
 
     # Advance the actionable date to the next_actionable_date value. Will modify

--- a/spec/models/solidus_subscriptions/line_item_spec.rb
+++ b/spec/models/solidus_subscriptions/line_item_spec.rb
@@ -63,4 +63,15 @@ RSpec.describe SolidusSubscriptions::LineItem, type: :model do
       expect(subject).to eq variant.price
     end
   end
+
+  describe '#next_actionable_date' do
+    subject { line_item.next_actionable_date }
+
+    around { |e| Timecop.freeze { e.run } }
+
+    let(:line_item) { create(:subscription_line_item, :with_subscription) }
+    let(:expected_date) { Time.zone.now + line_item.interval }
+
+    it { is_expected.to eq expected_date }
+  end
 end

--- a/spec/models/solidus_subscriptions/line_item_spec.rb
+++ b/spec/models/solidus_subscriptions/line_item_spec.rb
@@ -74,4 +74,33 @@ RSpec.describe SolidusSubscriptions::LineItem, type: :model do
 
     it { is_expected.to eq expected_date }
   end
+
+  describe '#as_json' do
+    subject { line_item.as_json }
+
+    around { |e| Timecop.freeze { e.run } }
+    let(:line_item) { create(:subscription_line_item, :with_subscription) }
+
+    let(:expected_hash) do
+      {
+        "id" => line_item.id,
+        "spree_line_item_id" => line_item.spree_line_item.id,
+        "subscription_id" => line_item.subscription_id,
+        "quantity" => line_item.quantity,
+        "max_installments" => line_item.max_installments,
+        "subscribable_id" => line_item.subscribable_id,
+        "created_at" => line_item.created_at,
+        "updated_at" => line_item.updated_at,
+        "interval_units" => line_item.interval_units,
+        "interval_length" => line_item.interval_length,
+        "price" => line_item.price.to_f,
+        "next_actionable_date" => line_item.next_actionable_date,
+        "name" => line_item.name
+      }
+    end
+
+    it 'is the json reporesentation of the line item' do
+      expect(subject).to eq(expected_hash)
+    end
+  end
 end

--- a/spec/models/solidus_subscriptions/line_item_spec.rb
+++ b/spec/models/solidus_subscriptions/line_item_spec.rb
@@ -28,4 +28,22 @@ RSpec.describe SolidusSubscriptions::LineItem, type: :model do
       expect(subject.from_now).to eq Date.parse("2016-10-22")
     end
   end
+
+  describe '#name' do
+    subject { line_item.name }
+
+    let(:line_item) do
+      create(
+        :subscription_line_item,
+        :with_subscription,
+        subscribable_id: variant.id
+      )
+    end
+
+    let(:variant) { create :variant, subscribable: true }
+
+    it 'is the name of the fulfilling variant' do
+      expect(subject).to eq variant.name
+    end
+  end
 end

--- a/spec/models/solidus_subscriptions/line_item_spec.rb
+++ b/spec/models/solidus_subscriptions/line_item_spec.rb
@@ -46,4 +46,21 @@ RSpec.describe SolidusSubscriptions::LineItem, type: :model do
       expect(subject).to eq variant.name
     end
   end
+
+  describe '#price' do
+    subject { line_item.price }
+
+    let(:variant) { create :variant, subscribable: true }
+    let(:line_item) do
+      create(
+        :subscription_line_item,
+        :with_subscription,
+        subscribable_id: variant.id
+      )
+    end
+
+    it 'is the price of the fulfilling variant' do
+      expect(subject).to eq variant.price
+    end
+  end
 end

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -124,4 +124,14 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
       expect{ subject }.to change { subscription.actionable_date }.to(nil)
     end
   end
+
+  describe '#line_item_builder' do
+    subject { subscription.line_item_builder }
+
+    let(:subscription) { create :subscription, :with_line_item }
+    let(:line_item) { subscription.line_item }
+
+    it { is_expected.to be_a SolidusSubscriptions::LineItemBuilder }
+    it { is_expected.to have_attributes(subscription_line_item: line_item) }
+  end
 end


### PR DESCRIPTION
There are a few values needed in the cart which have to be calculated,
given that subscriptions aren't created until after an order is
finalized.

Allow the subscription line item to calculate its: 
- name
- price
- next_actionable_date
