### PR TITLE
Update subscriptions

### DIFF
--- a/app/controllers/solidus_subscriptions/api/v1/line_items_controller.rb
+++ b/app/controllers/solidus_subscriptions/api/v1/line_items_controller.rb
@@ -25,7 +25,7 @@ class SolidusSubscriptions::Api::V1::LineItemsController < Spree::Api::BaseContr
 
   def line_item_params
     params.require(:subscription_line_item).permit(
-      SolidusSubscriptions::Config.subscription_line_item_attributes - [:subscribable_id]
+      SolidusSubscriptions::PermittedAttributes.subscription_line_item_attributes - [:subscribable_id]
     )
   end
 

--- a/app/decorators/spree/controllers/orders/subscription_params.rb
+++ b/app/decorators/spree/controllers/orders/subscription_params.rb
@@ -16,15 +16,3 @@ module Spree
 end
 
 Spree::OrdersController.prepend(Spree::Controllers::Orders::SubscriptionParams)
-
-# Allow spree line items to accept nested attributes for subscritption line items
-line_item_attributes = Spree::PermittedAttributes.line_item_attributes
-
-subscription_line_item_attributes = {
-  subscription_line_items_attributes: SolidusSubscriptions::Config.subscription_line_item_attributes
-}
-
-Spree::PermittedAttributes.class_variable_set(
-  '@@line_item_attributes',
-  line_item_attributes << subscription_line_item_attributes
-)

--- a/app/decorators/spree/users/have_many_subscriptions.rb
+++ b/app/decorators/spree/users/have_many_subscriptions.rb
@@ -16,17 +16,3 @@ module Spree
 end
 
 Spree.user_class.prepend(Spree::Users::HaveManySubscritptions)
-
-user_attributes = Spree::PermittedAttributes.user_attributes
-
-subscription_attributes = {
-  subscriptions_attributes: [
-    :id,
-    { line_item_attributes: SolidusSubscriptions::Config.subscription_line_item_attributes + [:id] }
-  ]
-}
-
-Spree::PermittedAttributes.class_variable_set(
-  '@@user_attributes',
-  user_attributes << subscription_attributes
-)

--- a/lib/solidus_subscriptions/engine.rb
+++ b/lib/solidus_subscriptions/engine.rb
@@ -9,6 +9,7 @@ module SolidusSubscriptions
     config.generators do |g|
       g.test_framework :rspec
     end
+    config.autoload_paths << config.root.join('lib')
 
     initializer 'solidus_subscriptions.configs', before: "spree.register.payment_methods" do
       require 'solidus_subscriptions/config'
@@ -20,6 +21,7 @@ module SolidusSubscriptions
       end
 
       Spree::Ability.register_ability(SolidusSubscriptions::Ability)
+      PermittedAttributes.update_spree_permiteed_attributes
     end
 
     config.to_prepare(&method(:activate).to_proc)

--- a/lib/solidus_subscriptions/permitted_attributes.rb
+++ b/lib/solidus_subscriptions/permitted_attributes.rb
@@ -1,0 +1,36 @@
+# This module is responsible for managing what attributes can be updated
+# through the api. It also overrides Spree::Permitted attributes to allow the
+# solidus api to accept nested params for subscription models as well
+module SolidusSubscriptions
+  module PermittedAttributes
+    class << self
+      def update_spree_permiteed_attributes
+        Spree::PermittedAttributes.line_item_attributes << {
+          subscription_line_items_attributes: nested(
+            subscription_line_item_attributes
+          )
+        }
+
+        Spree::PermittedAttributes.user_attributes << {
+          subscriptions_attributes: nested(subscription_attributes)
+        }
+      end
+
+      def subscription_line_item_attributes
+        Config.subscription_line_item_attributes
+      end
+
+      def subscription_attributes
+        [
+          { line_item_attributes: nested(subscription_line_item_attributes) - [:subscribable_id] }
+        ]
+      end
+
+      private
+
+      def nested(attributes)
+        attributes << :id
+      end
+    end
+  end
+end


### PR DESCRIPTION
Instead of overriding Spree::PermittedAttributes in various decorators,
group this override together in its own module.