### PR TITLE
Update actionable_date when interval changes

### DIFF
--- a/app/models/solidus_subscriptions/line_item.rb
+++ b/app/models/solidus_subscriptions/line_item.rb
@@ -36,6 +36,8 @@ module SolidusSubscriptions
     validates :quantity, :interval_length, numericality: { greater_than: 0 }
     validates :max_installments, numericality: { greater_than: 0 }, allow_blank: true
 
+    before_save :update_actionable_date_if_interval_changed
+
     # Calculates the number of seconds in the interval.
     #
     # @return [Integer] The number of seconds.
@@ -75,6 +77,24 @@ module SolidusSubscriptions
     # it is frozen and cannot be saved
     def dummy_subscription
       Subscription.new(line_item: dup).freeze
+    end
+
+    def update_actionable_date_if_interval_changed
+      if subscription && (interval_length_changed? || interval_units_changed?)
+        if subscription.installments.any?
+          new_date = interval.from_now(subscription.installments.last.created_at)
+          if new_date < Time.zone.now
+            # if the last installment plus the new interval is in the past, set
+            # the actionable_date to be now.
+            new_date = Time.zone.now
+          end
+        else
+          # if we have no installments, set the actionable date to be now.
+          new_date = interval.from_now(subscription.created_at)
+        end
+
+        subscription.actionable_date = new_date
+      end
     end
   end
 end

--- a/spec/models/solidus_subscriptions/line_item_spec.rb
+++ b/spec/models/solidus_subscriptions/line_item_spec.rb
@@ -107,9 +107,21 @@ RSpec.describe SolidusSubscriptions::LineItem, type: :model do
     end
 
     context "when there are no installments" do
-      it "sets the actionable_date to one interval past the subscription creation date" do
-        subject
-        expect(subscription.actionable_date).to eq Date.parse("2016-10-22")
+      context "when the subscription creation date would cause the interval to be in the past" do
+        before do
+          subscription.update(created_at: 4.months.ago)
+        end
+        it "sets the actionable_date to one interval past the subscription creation date" do
+          subject
+          expect(subscription.actionable_date).to eq Time.zone.now
+        end
+      end
+
+      context "when the subscription creation date would cause the interval to be in the future" do
+        it "sets the actionable_date to one interval past the subscription creation date" do
+          subject
+          expect(subscription.actionable_date).to eq Date.parse("2016-10-22")
+        end
       end
     end
   end

--- a/spec/models/solidus_subscriptions/line_item_spec.rb
+++ b/spec/models/solidus_subscriptions/line_item_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe SolidusSubscriptions::LineItem, type: :model do
 
   describe "#update_actionable_date_if_interval_changed" do
     let(:subscription) { create :subscription }
-    let(:line_item) { create :subscription_line_item, subscription: subscription, interval_length: 3, interval_units: "months" }
+    let(:line_item) { create :subscription_line_item, subscription: subscription, interval_length: 3, interval_units: "month" }
 
     before do
       Timecop.freeze(Date.parse("2016-09-22"))
@@ -82,7 +82,7 @@ RSpec.describe SolidusSubscriptions::LineItem, type: :model do
     end
     after { Timecop.return }
 
-    subject { line_item.update!(interval_length: 1, interval_units: "months") }
+    subject { line_item.update!(interval_length: 1, interval_units: "month") }
 
     context "with installments" do
       before do


### PR DESCRIPTION
If a subscription's line_item interval changes, we need to update the
actionable_date on the subscription in case the new interval means we
need to process the subscription immediately.

For example, if you have an interval of 3 months, and you change it to 1
month 2 months in, we should update the subscription to be actionable
immediately, as the new interval has passed since the last installment.