### PR TITLE
Change interval enum units to singular

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ To subscribe to a variant include the following parameters when posting to
       quantity: 2,              // number of units in each subscription order.
       subscribable_id: 1234,    // Which variant the subscription is for.
       interval_length: 1,       // The time between subscription activations.
-      interval_units: "months", // A plural qualifier for length.
-                                // Can be one of "days", "weeks", "months", or "years".
+      interval_units: "month", // A plural qualifier for length.
+                                // Can be one of "day", "week", "month", or "year".
       max_installments: 12      // Stop processing after this many subscription orders.
                                 // (use null to process the subscription ad nauseam)
     }

--- a/app/models/solidus_subscriptions/line_item.rb
+++ b/app/models/solidus_subscriptions/line_item.rb
@@ -26,10 +26,10 @@ module SolidusSubscriptions
     )
 
     enum interval_units: [
-      :days,
-      :weeks,
-      :months,
-      :years
+      :day,
+      :week,
+      :month,
+      :year
     ]
 
     validates :spree_line_item, :subscribable_id, presence: :true

--- a/app/models/solidus_subscriptions/line_item.rb
+++ b/app/models/solidus_subscriptions/line_item.rb
@@ -40,7 +40,7 @@ module SolidusSubscriptions
     #
     # @return [Integer] The number of seconds.
     def interval
-      ActiveSupport::Duration.new(interval_length, { interval_units.to_sym => interval_length })
+      ActiveSupport::Duration.new(interval_length, { interval_units.pluralize.to_sym => interval_length })
     end
 
     def next_actionable_date

--- a/docs/api/v1/subscriptions.md
+++ b/docs/api/v1/subscriptions.md
@@ -44,7 +44,7 @@ Make changes to the Subscription object or the subscription line item object
   "line_item_attributes": {
     "quantity": 5,
     "interval_length": 1,
-    "interval_units": "months"
+    "interval_units": "month"
   }
 }
 ```
@@ -69,7 +69,7 @@ HTTP/1.1 200 OK
     "subscribable_id": 2,
     "created_at": "2016-09-26T23:50:32.923Z",
     "updated_at": "2016-09-26T23:51:05.784Z",
-    "interval_units": "months",
+    "interval_units": "month",
     "interval_length": 1
    }
  }

--- a/lib/solidus_subscriptions/testing_support/factories/line_item_factory.rb
+++ b/lib/solidus_subscriptions/testing_support/factories/line_item_factory.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     subscribable_id { create(:variant, subscribable: true).id }
     quantity 1
     interval_length 1
-    interval_units :months
+    interval_units :month
 
     association :spree_line_item, factory: :line_item
 

--- a/spec/controllers/orders/create_subscription_line_items_spec.rb
+++ b/spec/controllers/orders/create_subscription_line_items_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Spree::Controllers::Orders::SubscriptionParams, type: :controller
             max_installments: 3,
             subscribable_id: variant.id,
             interval_length: 30,
-            interval_units: "days"
+            interval_units: "day"
           }
         }
       end

--- a/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/spec/controllers/spree/api/orders_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Spree::Api::OrdersController, type: :controller do
         quantity: 1,
         subscribable_id: variant.id,
         interval_length: 30,
-        interval_units: "days",
+        interval_units: "day",
         max_installments: 12
       }
     end

--- a/spec/controllers/spree/api/users_controller_spec.rb
+++ b/spec/controllers/spree/api/users_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Spree::Api::UsersController, type: :controller do
         id: subscription.line_item.id,
         quantity: 6,
         interval_length: 1,
-        interval_units: 'months'
+        interval_units: 'month'
       }
     end
 


### PR DESCRIPTION
This makes it easier for people on the frontend to pluralize, instead of
conditionally singularizing. Since this is an enum, this change makes
virtually no difference to us.