### PR TITLE
Actually set the actionable date

### DIFF
--- a/app/models/solidus_subscriptions/subscription_generator.rb
+++ b/app/models/solidus_subscriptions/subscription_generator.rb
@@ -11,7 +11,10 @@ module SolidusSubscriptions
     def self.activate(subscription_line_items)
       subscription_line_items.map do |subscription_line_item|
         user = subscription_line_item.order.user
-        Subscription.create!(user: user, line_item: subscription_line_item)
+
+        Subscription.create!(user: user, line_item: subscription_line_item) do |sub|
+          sub.actionable_date = sub.next_actionable_date
+        end
       end
     end
   end

--- a/spec/overrides/spree/orders/finalize_creates_subscrptions_spec.rb
+++ b/spec/overrides/spree/orders/finalize_creates_subscrptions_spec.rb
@@ -3,12 +3,28 @@ require 'rails_helper'
 RSpec.describe Spree::Orders::FinalizeCreatesSubscriptions do
   describe '#finalize!' do
     subject { order.finalize! }
+
     let(:order) { create :order, :with_subscription_line_items }
+    let(:subscription_line_item) { order.subscription_line_items.last }
+    let(:expected_actionable_date) { (Date.current + subscription_line_item.interval).to_date }
+
+    around { |e| Timecop.freeze { e.run } }
 
     it 'creates new subscriptions' do
       expect { subject }.
         to change { SolidusSubscriptions::Subscription.count }.
         by(order.subscription_line_items.count)
+    end
+
+    it 'creates a subscription with the correct values' do
+      subject
+      subscription = SolidusSubscriptions::Subscription.last
+
+      expect(subscription).to have_attributes(
+        user_id: order.user_id,
+        actionable_date: expected_actionable_date,
+        line_item: subscription_line_item
+      )
     end
   end
 end


### PR DESCRIPTION
When the order is finalized it should create a fully actionable
subscription. This means it includes an actionable date