### PR TITLE
Promo rule

### DIFF
--- a/app/models/solidus_subscriptions/subscription_promotion_rule.rb
+++ b/app/models/solidus_subscriptions/subscription_promotion_rule.rb
@@ -14,8 +14,7 @@ module SolidusSubscriptions
     # An order is eligible if it contains a line item with an associates
     # subscription_line_item.  This rule applies to order and so its eligibility
     # will always be considered against an order. Will only return true for
-    # orders containing # Spree::Line item with associated
-    # subscription_line_items
+    # orders containing Spree::Line item with associated subscription_line_items
     #
     # @param order [Spree::Order] The order which could have this rule applied
     #   to it.

--- a/app/models/solidus_subscriptions/subscription_promotion_rule.rb
+++ b/app/models/solidus_subscriptions/subscription_promotion_rule.rb
@@ -1,0 +1,39 @@
+module SolidusSubscriptions
+  class SubscriptionPromotionRule < Spree::PromotionRule
+    # Promotion can be applied to an entire order. Will only be true
+    # for Spree::Order
+    #
+    # @param promotable [Object] Any object which could have this
+    #   promotion rule applied to it.
+    #
+    # @return [Boolean]
+    def applicable?(promotable)
+      promotable.is_a? Spree::Order
+    end
+
+    # An order is eligible if it contains a line item with an associates
+    # subscription_line_item.  This rule applies to order and so its eligibility
+    # will always be considered against an order. Will only return true for
+    # orders containing # Spree::Line item with associated
+    # subscription_line_items
+    #
+    # @param order [Spree::Order] The order which could have this rule applied
+    #   to it.
+    #
+    # @return [Boolean]
+    def eligible?(order, **_options)
+      order.subscription_line_items.any?
+    end
+
+    # Certain actions create adjustments on line items. In this case, only
+    # line items with associated subscription_line_itms are eligible to be
+    # adjusted. Will only return true # if :line_item has an associated
+    # subscription.
+    #
+    # @param line_item [Spree::LineItem] The line item which could be adjusted
+    #   by the promotion.
+    def actionable?(line_item)
+      line_item.subscription_line_items.present?
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,3 +9,9 @@ en:
         stock.
       success: This installment has been processed successfully!
       failed: This installment could not be processed
+
+  spree:
+    promotion_rule_types:
+        subscription_promotion_rule:
+            name: Subscription
+            description: Order contains a subscription

--- a/lib/solidus_subscriptions/engine.rb
+++ b/lib/solidus_subscriptions/engine.rb
@@ -15,6 +15,10 @@ module SolidusSubscriptions
       require 'solidus_subscriptions/config'
     end
 
+    initializer 'register_subscription_promotion_rule', after: 'spree.promo.register.promotion.rules' do |app|
+      app.config.spree.promotions.rules << 'SolidusSubscriptions::SubscriptionPromotionRule'
+    end
+
     def self.activate
       Dir.glob(File.join(File.dirname(__FILE__), '../../app/decorators/**/*.rb')) do |c|
         Rails.configuration.cache_classes ? require(c) : load(c)

--- a/spec/models/solidus_subscriptions/subscription_promotion_rule_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_promotion_rule_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe SolidusSubscriptions::SubscriptionPromotionRule do
+  let(:rule) { described_class.new }
+
+  describe '#applicable' do
+    subject { rule.applicable? promotable }
+
+    context 'when the promotable is a Spree::Order' do
+      let(:promotable) { build_stubbed :order }
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when the promotable is not a Spree::Order' do
+      let(:promotable) { build_stubbed :line_item }
+      it { is_expected.to be_falsy }
+    end
+  end
+
+  describe '#eligible?' do
+    subject { rule.eligible? order }
+    let(:order) { create(:order, line_items: line_items) }
+
+    context 'when the order contains a line item with a subscription' do
+      let(:line_items) { build_list(:line_item, 1, :with_subscription_line_items) }
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when the order contains a line item with a subscription' do
+      let(:line_items) { build_list(:line_item, 1) }
+      it { is_expected.to be_falsy }
+    end
+  end
+
+  describe '#actionable?' do
+    subject { rule.actionable? line_item }
+
+    context 'when the line item has a subscription' do
+      let(:line_item) { build_stubbed(:line_item, :with_subscription_line_items) }
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when the line item has no subscription' do
+      let(:line_item) { build_stubbed :line_item }
+      it { is_expected.to be_falsy }
+    end
+  end
+end


### PR DESCRIPTION
Add the custom promotion rule to the list of solidus promotion rules.
add some translations and an empty template so that the admin can render
the promotion rule properly


This doesnt need an image... but Im stoked about it 
![subs_promo](https://cloud.githubusercontent.com/assets/6353433/18932065/b574e3ec-8583-11e6-87c2-019c76bc2446.png)
