### PR TITLE
Subscription order promo rule

### DIFF
--- a/app/models/solidus_subscriptions/consolidated_installment.rb
+++ b/app/models/solidus_subscriptions/consolidated_installment.rb
@@ -64,6 +64,7 @@ module SolidusSubscriptions
     private
 
     def checkout
+      order.update_totals
       apply_promotions
 
       order.next! # cart => address

--- a/app/models/solidus_subscriptions/consolidated_installment.rb
+++ b/app/models/solidus_subscriptions/consolidated_installment.rb
@@ -64,6 +64,8 @@ module SolidusSubscriptions
     private
 
     def checkout
+      apply_promotions
+
       order.next! # cart => address
 
       order.ship_address = ship_address
@@ -124,6 +126,11 @@ module SolidusSubscriptions
         amount: order.total,
         payment_method: Config.default_gateway
       )
+    end
+
+    def apply_promotions
+      Spree::PromotionHandler::Cart.new(order).activate
+      order.updater.update # reload totals
     end
   end
 end

--- a/app/models/solidus_subscriptions/subscription_order_promotion_rule.rb
+++ b/app/models/solidus_subscriptions/subscription_order_promotion_rule.rb
@@ -1,0 +1,25 @@
+module SolidusSubscriptions
+  class SubscriptionOrderPromotionRule < Spree::PromotionRule
+    # Promotion can be applied to an entire order. Will only be true
+    # for Spree::Order
+    #
+    # @param promotable [Object] Any object which could have this
+    #   promotion rule applied to it.
+    #
+    # @return [Boolean]
+    def applicable?(promotable)
+      promotable.is_a? Spree::Order
+    end
+
+    # An order is eligible if it fulfills a subscription Installment. Will only
+    # return true if the order fulfills one or more Installments
+    #
+    # @param order [Spree::Order] The order which could have this rule applied
+    #   to it.
+    #
+    # @return [Boolean]
+    def eligible?(order, **_options)
+      Installment.exists?(order: order)
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,9 @@ en:
 
   spree:
     promotion_rule_types:
-        subscription_promotion_rule:
-            name: Subscription
-            description: Order contains a subscription
+      subscription_promotion_rule:
+        name: Subscription
+        description: Order contains a subscription
+      subscription_order_promotion_rule:
+        name: Subscription Order
+        description: Order fulfills a subscription

--- a/lib/solidus_subscriptions/engine.rb
+++ b/lib/solidus_subscriptions/engine.rb
@@ -20,6 +20,7 @@ module SolidusSubscriptions
 
     initializer 'register_subscription_promotion_rule', after: 'spree.promo.register.promotion.rules' do |app|
       app.config.spree.promotions.rules << 'SolidusSubscriptions::SubscriptionPromotionRule'
+      app.config.spree.promotions.rules << 'SolidusSubscriptions::SubscriptionOrderPromotionRule'
     end
 
     def self.activate

--- a/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
+++ b/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
@@ -196,7 +196,9 @@ RSpec.describe SolidusSubscriptions::ConsolidatedInstallment do
     context 'when there are cart promotions' do
       let!(:promo) do
         create(
-          :promotion_with_order_adjustment,
+          :promotion,
+          :with_item_total_rule,
+          :with_order_adjustment,
           promo_params
         )
       end
@@ -204,14 +206,16 @@ RSpec.describe SolidusSubscriptions::ConsolidatedInstallment do
       # Promotions require the :apply_automatically flag to be auto applied in
       # solidus versions greater than 1.0
       let(:promo_params) do
-        { weighted_order_adjustment_amount: 0 }.tap do |params|
+        {}.tap do |params|
           if Spree::Promotion.new.respond_to?(:apply_automatically)
             params[:apply_automatically] = true
           end
         end
       end
 
-      it_behaves_like 'a completed checkout'
+      it_behaves_like 'a completed checkout' do
+        let(:total) { 39.98 }
+      end
 
       it 'applies the correct adjustments' do
         expect(subject.adjustments).to be_present

--- a/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
+++ b/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
@@ -228,6 +228,31 @@ RSpec.describe SolidusSubscriptions::ConsolidatedInstallment do
         expect(actionable_dates).to all eq expected_date
       end
     end
+
+    context 'when there are cart promotions' do
+      let!(:promo) do
+        create(
+          :promotion_with_order_adjustment,
+          promo_params
+        )
+      end
+
+      # Promotions require the :apply_automatically flag to be auto applied in
+      # solidus versions greater than 1.0
+      let(:promo_params) do
+        { weighted_order_adjustment_amount: 0 }.tap do |params|
+          if Spree::Promotion.new.respond_to?(:apply_automatically)
+            params[:apply_automatically] = true
+          end
+        end
+      end
+
+      it_behaves_like 'a completed checkout'
+
+      it 'applies the correct adjustments' do
+        expect(subject.adjustments).to be_present
+      end
+    end
   end
 
   describe '#order' do

--- a/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
+++ b/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
@@ -23,10 +23,12 @@ RSpec.describe SolidusSubscriptions::ConsolidatedInstallment do
 
     shared_examples 'a completed checkout' do
       it { is_expected.to be_a Spree::Order }
+      let(:total) { 49.98 }
+      let(:quantity) { installments.length }
 
       it 'has the correct number of line items' do
         count = order.line_items.length
-        expect(count).to eq installments.length
+        expect(count).to eq quantity
       end
 
       it 'the line items have the correct values' do
@@ -47,7 +49,7 @@ RSpec.describe SolidusSubscriptions::ConsolidatedInstallment do
 
       it 'has the correct totals' do
         expect(order).to have_attributes(
-          total: 49.98,
+          total: total,
           shipment_total: 10
         )
       end
@@ -56,7 +58,7 @@ RSpec.describe SolidusSubscriptions::ConsolidatedInstallment do
 
       it 'associates the order to the installments' do
         order
-        installment_orders = installments.map { |i| i.reload.order }
+        installment_orders = installments.map { |i| i.reload.order }.compact
         expect(installment_orders).to all eq order
       end
 
@@ -149,47 +151,9 @@ RSpec.describe SolidusSubscriptions::ConsolidatedInstallment do
           by(-1)
       end
 
-      it { is_expected.to be_a Spree::Order }
-
-      it 'has the correct number of line items' do
-        count = order.line_items.length
-        expect(count).to eq(installments.length - 1)
-      end
-
-      it 'the line items have the correct values' do
-        line_item = order.line_items.last
-        expect(line_item).to have_attributes(
-          quantity: subscription_line_item.quantity,
-          variant_id: subscription_line_item.subscribable_id
-        )
-      end
-
-      it 'has a shipment' do
-        expect(order.shipments).to be_present
-      end
-
-      it 'has a payment' do
-        expect(order.payments.valid).to be_present
-      end
-
-      it 'has the correct totals' do
-        expect(order).to have_attributes(
-          total: 29.99,
-          shipment_total: 10
-        )
-      end
-
-      it { is_expected.to be_complete }
-
-      it 'creates a installment detail for every installment' do
-        expect { subject }.to change { SolidusSubscriptions::InstallmentDetail.count }.by installments.length
-      end
-
-      it 'marks the installment to be reprocessed' do
-        subject
-        actionable_date = installments.first.reload.actionable_date
-
-        expect(actionable_date).to eq expected_date
+      it_behaves_like 'a completed checkout' do
+        let(:total) { 29.99 }
+        let(:quantity) { installments.length - 1 }
       end
     end
 

--- a/spec/models/solidus_subscriptions/subscription_order_promotion_rule_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_order_promotion_rule_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe SolidusSubscriptions::SubscriptionOrderPromotionRule do
+  let(:rule) { described_class.new }
+
+  describe '#applicable' do
+    subject { rule.applicable? promotable }
+
+    context 'when the promotable is a Spree::Order' do
+      let(:promotable) { build_stubbed :order }
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when the promotable is not a Spree::Order' do
+      let(:promotable) { build_stubbed :line_item }
+      it { is_expected.to be_falsy }
+    end
+  end
+
+  describe '#eligible?' do
+    subject { rule.eligible? order }
+    let(:order) { create(:order) }
+
+    context 'when the order fulfills a subscription installment' do
+      let!(:installment) { create(:installment, order: order) }
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when the order contains does not fulfill a subscription installment' do
+      it { is_expected.to be_falsy }
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,8 +1,7 @@
 # Run Coverage report
 require 'simplecov'
 SimpleCov.start do
-  add_filter 'spec/spec_helper.rb'
-  add_filter 'spec/dummy'
+  add_filter 'spec/'
   add_filter 'lib/solidus_subscriptions/engine.rb'
   add_group 'Controllers', 'app/controllers'
   add_group 'Helpers', 'app/helpers'


### PR DESCRIPTION
Add a promotion rule that targets orders creates as the result of processing a
subscription.

When creating new orders, run the order adjuster to take any applicable
promotions into account