### PR TITLE
Add #skip to subscriptions controller

### DIFF
--- a/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
+++ b/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
@@ -1,9 +1,17 @@
 class SolidusSubscriptions::Api::V1::SubscriptionsController < Spree::Api::BaseController
-  before_filter :load_subscription, only: [:cancel, :update]
+  before_filter :load_subscription, only: [:cancel, :update, :skip]
 
   def update
     if @subscription.update(subscription_params)
       render json: @subscription.to_json(include: :line_item)
+    else
+      render json: @subscription.errors.to_json, status: 422
+    end
+  end
+
+  def skip
+    if @subscription.advance_actionable_date
+      render json: @subscription.to_json
     else
       render json: @subscription.errors.to_json, status: 422
     end

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -46,7 +46,7 @@ module SolidusSubscriptions
         transition active: :pending_cancellation
       end
 
-      after_transition on: :cancel, do: :unset_actionable_date!
+      after_transition to: :canceled, do: :advance_actionable_date
 
       event :deactivate do
         transition active: :inactive,
@@ -95,6 +95,7 @@ module SolidusSubscriptions
     #   date after the current actionable_date this subscription will be
     #   eligible to be processed.
     def next_actionable_date
+      return nil unless active?
       (actionable_date || Time.zone.now) + interval
     end
 
@@ -106,13 +107,6 @@ module SolidusSubscriptions
     def advance_actionable_date
       update! actionable_date: next_actionable_date
       actionable_date
-    end
-
-    # Modify the record and set the actionable_date to nil.
-    #
-    # @return [SolidusSubscription::Subscription] The updated record.
-    def unset_actionable_date!
-      update!(actionable_date: nil)
     end
 
     # Get the builder for the subscription_line_item. This will be an

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ SolidusSubscriptions::Engine.routes.draw do
       resources :subscriptions, only: [:update] do
         member do
           post :cancel
+          post :skip
         end
       end
     end

--- a/docs/api/v1/subscriptions.md
+++ b/docs/api/v1/subscriptions.md
@@ -15,7 +15,7 @@ actionable date to prevent further processing.
 }
 ```
 
-## Example response
+### Example response
 
 ```
 HTTP/1.1 200 OK
@@ -49,7 +49,48 @@ Make changes to the Subscription object or the subscription line item object
 }
 ```
 
-## Example response
+### Example response
+```
+HTTP/1.1 200 OK
+
+{
+  "id": 1,
+  "actionable_date": nil,
+  "state": "active",
+  "user_id": 1,
+  "created_at": "2016-09-26T23:50:32.923Z",
+  "updated_at": "2016-09-26T23:50:32.923Z",
+  "line_item": {
+    "id": 1,
+    "spree_line_item_id": 1,
+    "subscription_id": 1,
+    "quantity": 5,
+    "max_installments": nil,
+    "subscribable_id": 2,
+    "created_at": "2016-09-26T23:50:32.923Z",
+    "updated_at": "2016-09-26T23:51:05.784Z",
+    "interval_units": "months",
+    "interval_length": 1
+   }
+ }
+
+```
+
+## POST `/api/v1/subscriptions/:id/skip`
+*Authentication Required*
+
+Advance the subscription by one extra interval, thereby skipping the next
+installment.
+
+### Example params
+
+```json
+{
+  "token": "userapitoken"
+}
+```
+
+### Example response
 ```
 HTTP/1.1 200 OK
 

--- a/spec/controllers/solidus_subscriptions/api/v1/subscriptions_controller_spec.rb
+++ b/spec/controllers/solidus_subscriptions/api/v1/subscriptions_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SolidusSubscriptions::Api::V1::SubscriptionsController, type: :co
 
   shared_examples "an authenticated subscription" do
     context "when the subscription belongs to user" do
-      let!(:subscription) { create :subscription, user: user }
+      let!(:subscription) { create :subscription, :with_line_item, user: user }
       it { is_expected.to be_success }
     end
 
@@ -17,7 +17,7 @@ RSpec.describe SolidusSubscriptions::Api::V1::SubscriptionsController, type: :co
       it { is_expected.to be_not_found }
     end
 
-    context 'when the subscription is already cancelled' do
+    context 'when the subscription is canceled' do
       let!(:subscription) { create :subscription, user: user, state: 'canceled' }
       it { is_expected.to be_unprocessable }
     end

--- a/spec/controllers/solidus_subscriptions/api/v1/subscriptions_controller_spec.rb
+++ b/spec/controllers/solidus_subscriptions/api/v1/subscriptions_controller_spec.rb
@@ -6,10 +6,7 @@ RSpec.describe SolidusSubscriptions::Api::V1::SubscriptionsController, type: :co
   let!(:user) { create :user }
   before { user.generate_spree_api_key! }
 
-  describe "POST :cancel" do
-    let(:params) { { id: subscription.id, token: user.spree_api_key } }
-    subject { post :cancel, params }
-
+  shared_examples "an authenticated subscription" do
     context "when the subscription belongs to user" do
       let!(:subscription) { create :subscription, user: user }
       it { is_expected.to be_success }
@@ -67,5 +64,19 @@ RSpec.describe SolidusSubscriptions::Api::V1::SubscriptionsController, type: :co
       let!(:subscription) { create :subscription, :with_line_item, user: create(:user) }
       it { is_expected.to be_not_found }
     end
+  end
+
+  describe "POST :skip" do
+    let(:params) { { id: subscription.id, token: user.spree_api_key } }
+    subject { post :skip, params }
+
+    it_behaves_like "an authenticated subscription"
+  end
+
+  describe "POST :cancel" do
+    let(:params) { { id: subscription.id, token: user.spree_api_key } }
+    subject { post :cancel, params }
+
+    it_behaves_like "an authenticated subscription"
   end
 end

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -61,16 +61,23 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
   describe '#next_actionable_date' do
     subject { subscription.next_actionable_date }
 
-    let(:expected_date) { Date.current + subscription.interval }
-    let(:subscription) do
-      build_stubbed(
-        :subscription,
-        :with_line_item,
-        actionable_date: Date.current
-      )
+    context "when the subscription is active" do
+      let(:expected_date) { Date.current + subscription.interval }
+      let(:subscription) do
+        build_stubbed(
+          :subscription,
+          :with_line_item,
+          actionable_date: Date.current
+        )
+      end
+
+      it { is_expected.to eq expected_date }
     end
 
-    it { is_expected.to eq expected_date }
+    context "when the subscription is not active" do
+      let(:subscription) { build_stubbed :subscription, :with_line_item, state: :canceled }
+      it { is_expected.to be_nil }
+    end
   end
 
   describe '#advance_actionable_date' do
@@ -117,15 +124,6 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
 
     it "does not include canceled subscriptions" do
       expect(subject).to_not include canceled_subscription
-    end
-  end
-
-  describe ".unset_actionable_date!" do
-    let!(:subscription) { create :subscription, actionable_date: 1.day.from_now }
-    subject { subscription.unset_actionable_date! }
-
-    it "removes the actionable_date from the record" do
-      expect{ subject }.to change { subscription.actionable_date }.to(nil)
     end
   end
 

--- a/spec/requests/solidus_subscriptions/api/v1/subscriptions_spec.rb
+++ b/spec/requests/solidus_subscriptions/api/v1/subscriptions_spec.rb
@@ -14,4 +14,17 @@ RSpec.describe "Subscription endpoints", type: :request do
       expect(json_resp["actionable_date"]).to be_nil
     end
   end
+
+  describe "#skip" do
+    let(:subscription) { create :subscription, :with_line_item, actionable_date: 1.day.from_now, user: user }
+    before { Timecop.freeze(Date.parse("2016-09-26")) }
+    after  { Timecop.return }
+
+    let(:expected_date) { "2016-10-27" }
+
+    it "returns the updated record", :aggregate_failures do
+      post solidus_subscriptions.skip_api_v1_subscription_path(subscription), token: user.spree_api_key
+      expect(json_resp["actionable_date"]).to eq expected_date
+    end
+  end
 end


### PR DESCRIPTION
Allows the caller to defer their subscription installment for another
month. This just bumps the actionable_date so it won't be processed
during the next rake task invocation.