### PR TITLE
Rerun promotion handler

### DIFF
--- a/app/decorators/spree/controllers/orders/create_subscription_line_items.rb
+++ b/app/decorators/spree/controllers/orders/create_subscription_line_items.rb
@@ -23,6 +23,9 @@ module Spree
           SolidusSubscriptions::LineItem.create!(
             subscription_params.merge(spree_line_item: line_item)
           )
+
+          # Rerun the promotion handler to pickup subscription promotions
+          Spree::PromotionHandler::Cart.new(current_order).activate
         end
 
         def line_item


### PR DESCRIPTION
Some promotions act on subscription_line_items, make sure to rerun the
promotion handler after they are created