### PR TITLE
Make next_actionable_date nil when not active

### DIFF
--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -46,7 +46,7 @@ module SolidusSubscriptions
         transition active: :pending_cancellation
       end
 
-      after_transition on: :cancel, do: :unset_actionable_date!
+      after_transition to: :canceled, do: :advance_actionable_date
 
       event :deactivate do
         transition active: :inactive,
@@ -95,6 +95,7 @@ module SolidusSubscriptions
     #   date after the current actionable_date this subscription will be
     #   eligible to be processed.
     def next_actionable_date
+      return nil unless active?
       (actionable_date || Time.zone.now) + interval
     end
 
@@ -106,13 +107,6 @@ module SolidusSubscriptions
     def advance_actionable_date
       update! actionable_date: next_actionable_date
       actionable_date
-    end
-
-    # Modify the record and set the actionable_date to nil.
-    #
-    # @return [SolidusSubscription::Subscription] The updated record.
-    def unset_actionable_date!
-      update!(actionable_date: nil)
     end
 
     # Get the builder for the subscription_line_item. This will be an

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -61,16 +61,23 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
   describe '#next_actionable_date' do
     subject { subscription.next_actionable_date }
 
-    let(:expected_date) { Date.current + subscription.interval }
-    let(:subscription) do
-      build_stubbed(
-        :subscription,
-        :with_line_item,
-        actionable_date: Date.current
-      )
+    context "when the subscription is active" do
+      let(:expected_date) { Date.current + subscription.interval }
+      let(:subscription) do
+        build_stubbed(
+          :subscription,
+          :with_line_item,
+          actionable_date: Date.current
+        )
+      end
+
+      it { is_expected.to eq expected_date }
     end
 
-    it { is_expected.to eq expected_date }
+    context "when the subscription is not active" do
+      let(:subscription) { build_stubbed :subscription, :with_line_item, state: :canceled }
+      it { is_expected.to be_nil }
+    end
   end
 
   describe '#advance_actionable_date' do
@@ -117,15 +124,6 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
 
     it "does not include canceled subscriptions" do
       expect(subject).to_not include canceled_subscription
-    end
-  end
-
-  describe ".unset_actionable_date!" do
-    let!(:subscription) { create :subscription, actionable_date: 1.day.from_now }
-    subject { subscription.unset_actionable_date! }
-
-    it "removes the actionable_date from the record" do
-      expect{ subject }.to change { subscription.actionable_date }.to(nil)
     end
   end
 


### PR DESCRIPTION
If the subscription is not active, then there is no next actionable
date, so this should be set to nil. This also relieves the need for the
`unset_actionable_date` method.