### PR TITLE
Prefer hash conditions over blocks

### DIFF
--- a/lib/solidus_subscriptions/ability.rb
+++ b/lib/solidus_subscriptions/ability.rb
@@ -7,7 +7,7 @@ module SolidusSubscriptions
         li.order.user == user || li.order == order
       end
 
-      can(:manage, Subscription) { |s| s.user == user }
+      can(:manage, Subscription, user_id: user.id)
     end
   end
 end


### PR DESCRIPTION
The hash conditions are more flexible and allow the permission set to be
used in more circumstances

https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities%3A-Best-Practice