### PR TITLE
Reload order totals after applying promotions

### DIFF
--- a/app/models/solidus_subscriptions/subscription_line_item_builder.rb
+++ b/app/models/solidus_subscriptions/subscription_line_item_builder.rb
@@ -9,6 +9,7 @@ module SolidusSubscriptions
 
       # Rerun the promotion handler to pickup subscription promotions
       Spree::PromotionHandler::Cart.new(line_item.order).activate
+      line_item.order.update!
     end
 
     def subscription_params


### PR DESCRIPTION
If we dont recalculate the order totals after applying promotions to
account for subscriptions, the total values will be wrong