### PR TITLE
Allow guests to edit their subss line items

### DIFF
--- a/app/controllers/solidus_subscriptions/api/v1/line_items_controller.rb
+++ b/app/controllers/solidus_subscriptions/api/v1/line_items_controller.rb
@@ -3,7 +3,7 @@ class SolidusSubscriptions::Api::V1::LineItemsController < Spree::Api::BaseContr
   wrap_parameters :subscription_line_item
 
   def update
-    authorize! :manage, @line_item
+    authorize! :manage, @line_item, @order
     if @line_item.update(line_item_params)
       render json: @line_item.to_json
     else
@@ -12,7 +12,7 @@ class SolidusSubscriptions::Api::V1::LineItemsController < Spree::Api::BaseContr
   end
 
   def destroy
-    authorize! :manage, @line_item
+    authorize! :manage, @line_item, @order
     return render json: {}, status: 400 if @line_item.order.complete?
 
     @line_item.destroy!

--- a/lib/solidus_subscriptions/ability.rb
+++ b/lib/solidus_subscriptions/ability.rb
@@ -3,7 +3,10 @@ module SolidusSubscriptions
     include CanCan::Ability
 
     def initialize(user)
-      can(:manage, LineItem) { |li| li.order.user == user }
+      can(:manage, LineItem) do |li, order|
+        li.order.user == user || li.order == order
+      end
+
       can(:manage, Subscription) { |s| s.user == user }
     end
   end

--- a/spec/controllers/solidus_subscriptions/api/v1/line_items_controller_spec.rb
+++ b/spec/controllers/solidus_subscriptions/api/v1/line_items_controller_spec.rb
@@ -18,6 +18,41 @@ RSpec.describe SolidusSubscriptions::Api::V1::LineItemsController, type: :contro
     end
     subject { post :update, params }
 
+    context 'guest user' do
+      let(:order) { create :order }
+
+      let(:params) do
+        {
+          id: line.id,
+          subscription_line_item: { quantity: 21 },
+          checkout_id: order.number,
+          order_token: order.guest_token
+        }
+      end
+
+      context "with valid params" do
+        let(:json_body) { JSON.parse(subject.body) }
+
+        it { is_expected.to be_success }
+        it "returns the updated record" do
+          expect(json_body["quantity"]).to eq 21
+        end
+      end
+
+      context "with invalid params" do
+        let(:params) do
+          {
+            id: line.id,
+            subscription_line_item: { max_installments: "lots" },
+            checkout_id: order.number,
+            order_token: order.guest_token
+          }
+        end
+
+        it { is_expected.to be_unprocessable }
+      end
+    end
+
     context "when the order belongs to the user" do
       let(:order) { create :order, user: user }
 


### PR DESCRIPTION
Previously the ability assumed that all subscription_line_items would
have a user through the order. This however is not the case since the
user login is not enforced until after the user tries to transition out
of the cart step.

Allow guests to edit their line items if the line item matches the
current checkout_id (order guest token )