### PR TITLE
Skips

### DIFF
--- a/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
+++ b/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
@@ -10,7 +10,7 @@ class SolidusSubscriptions::Api::V1::SubscriptionsController < Spree::Api::BaseC
   end
 
   def skip
-    if @subscription.advance_actionable_date
+    if @subscription.skip
       render json: @subscription.to_json
     else
       render json: @subscription.errors.to_json, status: 422

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -9,6 +9,7 @@ module SolidusSubscriptions
     has_one :root_order, through: :line_item, class_name: 'Spree::Order', source: :order
 
     validates :user, presence: :true
+    validates :skip_count, :successive_skip_count, presence: true, numericality: { greater_than_or_equal_to: 0 }
 
     accepts_nested_attributes_for :line_item
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,3 +25,17 @@ en:
         pending: new
         success: success
         failed: failure
+
+    errors:
+      models:
+        solidus_subscriptions/subscription:
+          attributes:
+            successive_skip_count:
+              exceeded: >
+                This subscription has exceeded the maximum configured successive
+                skip limit. It can be skipped again after the next time it is
+                processed.
+            skip_count:
+              exceeded: >
+                This subscription has exceeded the maximum configured skip
+                limit. It can no longer be skipped.

--- a/db/migrate/20161006191003_add_skip_count_to_solidus_subscriptions_subscriptions.rb
+++ b/db/migrate/20161006191003_add_skip_count_to_solidus_subscriptions_subscriptions.rb
@@ -1,0 +1,5 @@
+class AddSkipCountToSolidusSubscriptionsSubscriptions < ActiveRecord::Migration
+  def change
+    add_column :solidus_subscriptions_subscriptions, :skip_count, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20161006191127_add_successive_skip_count_to_solidus_subscriptions_subscriptions.rb
+++ b/db/migrate/20161006191127_add_successive_skip_count_to_solidus_subscriptions_subscriptions.rb
@@ -1,0 +1,5 @@
+class AddSuccessiveSkipCountToSolidusSubscriptionsSubscriptions < ActiveRecord::Migration
+  def change
+    add_column :solidus_subscriptions_subscriptions, :successive_skip_count, :integer, default: 0, null: false
+  end
+end

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,6 +14,14 @@ SolidusSubscriptions::Config.default_gateway = my_gateway
 # be reprocessed by the `Processor`
 SolidusSubscriptions::Config.reprocessing_interval = 1.days
 
+# Maximum number of times a user can skip their subscription before it
+# must be processed
+mattr_accessor(:maximum_successive_skips) { 1 }
+
+# Limit on the number of times a user can skip thier subscription. Once
+# this limit is reached, no skips are permitted
+mattr_accessor(:maximum_total_skips) { nil }
+
 # Notice required to cancel a subscription. A cancellation with insufficient
 # notice will result in the subscription being moved to the
 # `pending_cancellation` state. Subscriptions pending cancellations will be

--- a/lib/solidus_subscriptions/config.rb
+++ b/lib/solidus_subscriptions/config.rb
@@ -1,6 +1,14 @@
 module SolidusSubscriptions
   module Config
     class << self
+      # Maximum number of times a user can skip their subscription before it
+      # must be processed
+      mattr_accessor(:maximum_successive_skips) { 1 }
+
+      # Limit on the number of times a user can skip thier subscription. Once
+      # this limit is reached, no skips are permitted
+      mattr_accessor(:maximum_total_skips) { nil }
+
       # Time between an installment failing to be processed and the system
       # retrying to fulfil it
       mattr_accessor(:reprocessing_interval) { 1.day }

--- a/lib/solidus_subscriptions/processor.rb
+++ b/lib/solidus_subscriptions/processor.rb
@@ -82,6 +82,7 @@ module SolidusSubscriptions
     def new_installments(user)
       subscriptions_by_id.fetch(user.id, []).map do |sub|
         ActiveRecord::Base.transaction do
+          sub.successive_skip_count = 0
           sub.advance_actionable_date
           sub.cancel! if sub.pending_cancellation?
           sub.installments.create!

--- a/spec/lib/solidus_subscriptions/processor_spec.rb
+++ b/spec/lib/solidus_subscriptions/processor_spec.rb
@@ -64,6 +64,13 @@ RSpec.describe SolidusSubscriptions::Processor, :checkout do
         to change { subs.reload.state }.
         from('pending_cancellation').to('canceled')
     end
+
+    it 'resets the subscription successive skip count' do
+      subs = pending_cancellation_subscriptions.first
+      expect { subject }.
+        to change { subs.reload.state }.
+        from('pending_cancellation').to('canceled')
+    end
   end
 
   describe '.run' do

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -4,7 +4,12 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
   it { is_expected.to have_many :installments }
   it { is_expected.to belong_to :user }
   it { is_expected.to have_one :line_item }
+
   it { is_expected.to validate_presence_of :user }
+  it { is_expected.to validate_presence_of :skip_count }
+  it { is_expected.to validate_presence_of :successive_skip_count }
+  it { is_expected.to validate_numericality_of(:skip_count).is_greater_than_or_equal_to(0) }
+  it { is_expected.to validate_numericality_of(:successive_skip_count).is_greater_than_or_equal_to(0) }
 
   it { is_expected.to accept_nested_attributes_for :line_item }
 


### PR DESCRIPTION
Allow the actionable date of a subscription to be advanced if it has not
exceeded the configurable skip limits

maximum_successive_skips: maximum number of times a subscription can be
skipped before it must be processed.

maximum_total_skips: Total limit on number of skips, once a subscription
has been skipped this many times, the subscription can no longer be
skipped