### PR TITLE
Only process consolidated installments for the same user

### DIFF
--- a/app/models/solidus_subscriptions/consolidated_installment.rb
+++ b/app/models/solidus_subscriptions/consolidated_installment.rb
@@ -16,6 +16,7 @@ module SolidusSubscriptions
     # to be used when generating a new order
     def initialize(installments)
       @installments = installments
+      raise UserMismatchError.new(installments) if different_owners?
     end
 
     # Generate a new Spree::Order based on the information associated to the
@@ -137,6 +138,10 @@ module SolidusSubscriptions
     def apply_promotions
       Spree::PromotionHandler::Cart.new(order).activate
       order.updater.update # reload totals
+    end
+
+    def different_owners?
+      installments.map { |i| i.subscription.user }.uniq.length > 1
     end
   end
 end

--- a/app/models/solidus_subscriptions/user_mismatch_error.rb
+++ b/app/models/solidus_subscriptions/user_mismatch_error.rb
@@ -1,0 +1,15 @@
+module SolidusSubscriptions
+  class UserMismatchError < StandardError
+    def initialize(installments)
+      @installments = installments
+    end
+
+    def to_s
+      <<-MSG.squish
+        Installments must have the same user to be processed as a consolidated
+        installment. Could not process installments:
+        #{@installments.map(&:id).join(', ')}
+      MSG
+    end
+  end
+end

--- a/spec/jobs/solidus_subscriptions/process_installments_job_spec.rb
+++ b/spec/jobs/solidus_subscriptions/process_installments_job_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe SolidusSubscriptions::ProcessInstallmentsJob do
   let(:installments) do
     traits = {
       subscription_traits: [{
+        user: root_order.user,
         line_item_traits: [{
           spree_line_item: root_order.line_items.first
         }]

--- a/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
+++ b/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe SolidusSubscriptions::ConsolidatedInstallment do
     create_list(:installment, 2, traits)
   end
 
+  context 'initialized with installments belonging to multiple users' do
+    subject { consolidated_installment }
+    let(:installments) { build_stubbed_list :installment, 2 }
+
+    it 'raises an error' do
+      expect { subject }.
+        to raise_error SolidusSubscriptions::UserMismatchError, /must have the same user/
+    end
+  end
+
   describe '#process', :checkout do
     subject(:order) { consolidated_installment.process }
     let(:subscription_line_item) { installments.first.subscription.line_item }


### PR DESCRIPTION
Consolidated installments make the assumption that all installments
passed in share the same user. This is a critical assumption that I feel
merrits a validation.

An error will be raised with the ids of the installments which were
attempted to be consolidated.