### PR TITLE
Make the dispatchers pluggable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,3 +44,21 @@ SolidusSubscriptions::Config.subscription_line_item_attributes = [
   :interval_units,
   :max_installments
 ]
+
+# Dispatchers (processing callbacks)
+
+# These handlers are pluggable, however it is highly encouraged that you
+# subclass from the the dispatcher you are replacing, and call super
+# from within the #dispatch method (if you override it)
+
+# This handler is called when a susbcription order is successfully placed.
+SolidusSubscriptions::Config.success_dispatcher_class = ::SolidusSubscriptions::SuccessDispatcher
+
+# This handler is called when an order cant be placed for a group of installments
+SolidusSubscriptions::Config.failure_dispatcher_class = ::SolidusSubscriptions::FailureDispatcher
+
+# This handler is called when a payment fails on a subscription order
+SolidusSubscriptions::Config.payment_failed_dispatcher_class = ::SolidusSubscriptions::PaymentFailedDispatcher
+
+# This handler is called when installemnts cannot be fulfilled due to lack of stock
+SolidusSubscriptions::Config.out_of_stock_dispatcher_class = ::SolidusSubscriptions::OutOfStockDispatcher

--- a/lib/solidus_subscriptions/config.rb
+++ b/lib/solidus_subscriptions/config.rb
@@ -1,6 +1,37 @@
 module SolidusSubscriptions
   module Config
     class << self
+      # Processing Event handlers
+      # These handlers are pluggable, however it is highly encouraged that you
+      # subclass from the the dispatcher you are replacing, and call super
+      # from within the #dispatch method (if you override it)
+      #
+      # This handler is called when a susbcription order is successfully placed.
+      attr_writer :success_dispatcher_class
+      def success_dispatcher_class
+        @success_dispatcher_class ||= ::SolidusSubscriptions::SuccessDispatcher
+      end
+
+      # This handler is called when an order cant be placed for a group of
+      # installments
+      attr_writer :failure_dispatcher_class
+      def failure_dispatcher_class
+        @failure_dispatcher_class ||= ::SolidusSubscriptions::FailureDispatcher
+      end
+
+      # This handler is called when a payment fails on a subscription order
+      attr_writer :payment_failed_dispatcher_class
+      def payment_failed_dispatcher_class
+        @payment_failed_dispatcher_class ||= ::SolidusSubscriptions::PaymentFailedDispatcher
+      end
+
+      # This handler is called when installemnts cannot be fulfilled due to lack
+      # of stock
+      attr_writer :out_of_stock_dispatcher
+      def out_of_stock_dispatcher_class
+        @out_of_stock_dispatcher_class ||= ::SolidusSubscriptions::OutOfStockDispatcher
+      end
+
       # Maximum number of times a user can skip their subscription before it
       # must be processed
       mattr_accessor(:maximum_successive_skips) { 1 }


### PR DESCRIPTION
The dispatcher classes are intended to be hooks into the proccing
algorithm.

Allowing these classes to be plugged into the gem gives users more
flexibility as to how their app handles certain events during handling.

These events are:

Success - All installments were processed and fulfilled by a single
  order
Failure - No installments were fulfilled due to a generic error
OutOfStock - Some installments were not fulfilled because there was
  insufficient stock to do so
PaymentFailed - No installments were fulfilled due do a payment error.

When plugging in a new class it is highly recommented to subclass from
the dispatcher you are replacing, and call super if you override the
 #dipatch method. This ensures the internal models handled correctly.
Custom behaviour should be added in addition to the existing behaviour.

ex.

```ruby
Class MyAppFailureHandler < SolidusSubscriptions::FailureHandler
  def dispatch(installments)
    email_client(installment.first.subscription.user)
    super # very important
  end

  def email_client(user)
    Mailer.send_later(:subscription_error, user)
  end
end
```