### PR TITLE
Spec store credit subs orders

### DIFF
--- a/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
+++ b/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
@@ -254,6 +254,15 @@ RSpec.describe SolidusSubscriptions::ConsolidatedInstallment do
           and change { Spree::Order.count }.by(0)
       end
     end
+
+    context 'the user has store credit' do
+      it_behaves_like 'a completed checkout'
+      let!(:store_credit) { create :store_credit, user: subscription_user }
+
+      it 'has a valid store credit payment' do
+        expect(order.payments.valid.store_credits).to be_present
+      end
+    end
   end
 
   describe '#order' do


### PR DESCRIPTION
This is a sanity check spec to make sure store credits are applied to
subscription orders during the checkout.

This is solidus default behaviour, and while it may not be the desired
behaviour for every subscription implementation. Changeing this default
behaviour could be intensive. I am opting to wait for this to be a
feature requeset before implementing the ability to blacklist store
credit on subs orders