### PR TITLE
Remove spree_line_item validation

### DIFF
--- a/app/models/solidus_subscriptions/line_item.rb
+++ b/app/models/solidus_subscriptions/line_item.rb
@@ -32,7 +32,7 @@ module SolidusSubscriptions
       :year
     ]
 
-    validates :spree_line_item, :subscribable_id, presence: :true
+    validates :subscribable_id, presence: :true
     validates :quantity, :interval_length, numericality: { greater_than: 0 }
     validates :max_installments, numericality: { greater_than: 0 }, allow_blank: true
 

--- a/spec/models/solidus_subscriptions/line_item_spec.rb
+++ b/spec/models/solidus_subscriptions/line_item_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe SolidusSubscriptions::LineItem, type: :model do
   it { is_expected.to belong_to :subscription }
   it { is_expected.to have_one :order }
 
-  it { is_expected.to validate_presence_of :spree_line_item }
   it { is_expected.to validate_presence_of :subscribable_id }
 
   it { is_expected.to validate_numericality_of(:quantity).is_greater_than(0) }


### PR DESCRIPTION
Subscriptions created through the backed do not require a purchasing
order (line item).