### PR TITLE
Checkout rework

### DIFF
--- a/app/decorators/spree/orders/after_create.rb
+++ b/app/decorators/spree/orders/after_create.rb
@@ -1,0 +1,15 @@
+module Spree
+  module Orders
+    module AfterCreate
+      def ensure_line_items_present
+        super unless subscription_order?
+      end
+
+      def send_cancel_email
+        super unless subscription_order?
+      end
+    end
+
+    Order.prepend(AfterCreate)
+  end
+end

--- a/app/models/solidus_subscriptions/consolidated_installment.rb
+++ b/app/models/solidus_subscriptions/consolidated_installment.rb
@@ -57,7 +57,8 @@ module SolidusSubscriptions
       @order ||= Spree::Order.create(
         user: user,
         email: user.email,
-        store: root_order.store
+        store: root_order.store,
+        subscription_order: true
       )
     end
 

--- a/app/models/solidus_subscriptions/consolidated_installment.rb
+++ b/app/models/solidus_subscriptions/consolidated_installment.rb
@@ -39,7 +39,7 @@ module SolidusSubscriptions
 
       # A new order will only have 1 payment that we created
       if order.payments.any?(&:failed?)
-        Config.payment_failed_dispatcher_class.new(installments).dispatch
+        Config.payment_failed_dispatcher_class.new(installments, order).dispatch
         installments.clear
         nil
       end

--- a/app/models/solidus_subscriptions/consolidated_installment.rb
+++ b/app/models/solidus_subscriptions/consolidated_installment.rb
@@ -31,9 +31,7 @@ module SolidusSubscriptions
       return if installments.empty?
 
       if checkout
-        # Associate the order with the fulfilled installments
-        installments.each { |installment| installment.update!(order_id: order.id) }
-        Config.success_dispatcher_class.new(installments).dispatch
+        Config.success_dispatcher_class.new(installments, order).dispatch
         return order
       end
 

--- a/app/models/solidus_subscriptions/consolidated_installment.rb
+++ b/app/models/solidus_subscriptions/consolidated_installment.rb
@@ -41,14 +41,14 @@ module SolidusSubscriptions
       if order.payments.any?(&:failed?)
         Config.payment_failed_dispatcher_class.new(installments).dispatch
         installments.clear
-        order.destroy!
         nil
       end
     ensure
       # Any installments that failed to be processed will be reprocessed
       unfulfilled_installments = installments.select(&:unfulfilled?)
       if unfulfilled_installments.any?
-        Config.failure_dispatcher_class.new(unfulfilled_installments).dispatch
+        Config.failure_dispatcher_class.
+          new(unfulfilled_installments, order).dispatch
       end
     end
 

--- a/app/models/solidus_subscriptions/consolidated_installment.rb
+++ b/app/models/solidus_subscriptions/consolidated_installment.rb
@@ -57,7 +57,7 @@ module SolidusSubscriptions
       @order ||= Spree::Order.create(
         user: user,
         email: user.email,
-        store: root_order.store,
+        store: root_order.try!(:store) || Spree::Store.default,
         subscription_order: true
       )
     end

--- a/app/models/solidus_subscriptions/dispatcher.rb
+++ b/app/models/solidus_subscriptions/dispatcher.rb
@@ -1,6 +1,6 @@
 module SolidusSubscriptions
   class Dispatcher
-    attr_reader :installments
+    attr_reader :installments, :order
 
     # Get a new instance of the FailureDispatcher
     #
@@ -8,8 +8,9 @@ module SolidusSubscriptions
     #   installments which have failed to be fulfilled
     #
     # @return [SolidusSubscriptions::FailureDispatcher]
-    def initialize(installments)
+    def initialize(installments, order = nil)
       @installments = installments
+      @order = order
     end
 
     def dispatch

--- a/app/models/solidus_subscriptions/failure_dispatcher.rb
+++ b/app/models/solidus_subscriptions/failure_dispatcher.rb
@@ -3,7 +3,7 @@
 module SolidusSubscriptions
   class FailureDispatcher < Dispatcher
     def dispatch
-      installments.each(&:failed)
+      installments.each { |i| i.failed!(order) }
       super
     end
 

--- a/app/models/solidus_subscriptions/failure_dispatcher.rb
+++ b/app/models/solidus_subscriptions/failure_dispatcher.rb
@@ -3,6 +3,8 @@
 module SolidusSubscriptions
   class FailureDispatcher < Dispatcher
     def dispatch
+      order.touch :completed_at
+      order.cancel!
       installments.each { |i| i.failed!(order) }
       super
     end

--- a/app/models/solidus_subscriptions/installment.rb
+++ b/app/models/solidus_subscriptions/installment.rb
@@ -85,11 +85,12 @@ module SolidusSubscriptions
     #
     # @return [SolidusSubscriptions::InstallmentDetail] The record of the
     #   failed processing attempt
-    def payment_failed!
+    def payment_failed!(order)
       advance_actionable_date!
 
       details.create!(
         success: false,
+        order: order,
         message: I18n.t('solidus_subscriptions.installment_details.payment_failed')
       )
     end

--- a/app/models/solidus_subscriptions/installment.rb
+++ b/app/models/solidus_subscriptions/installment.rb
@@ -47,6 +47,9 @@ module SolidusSubscriptions
 
     # Mark this installment as a success
     #
+    # @param order [Spree::Order] The order generated for this processing
+    #   attempt
+    #
     # @return [SolidusSubscriptions::InstallmentDetail] The record of the
     #   successful processing attempt
     def success!(order)
@@ -60,6 +63,9 @@ module SolidusSubscriptions
     end
 
     # Mark this installment as a failure
+    #
+    # @param order [Spree::Order] The order generated for this processing
+    #   attempt
     #
     # @return [SolidusSubscriptions::InstallmentDetail] The record of the
     #   failed processing attempt
@@ -88,6 +94,9 @@ module SolidusSubscriptions
     end
 
     # Mark this installment as having a failed payment
+    #
+    # @param order [Spree::Order] The order generated for this processing
+    #   attempt
     #
     # @return [SolidusSubscriptions::InstallmentDetail] The record of the
     #   failed processing attempt

--- a/app/models/solidus_subscriptions/installment.rb
+++ b/app/models/solidus_subscriptions/installment.rb
@@ -71,14 +71,14 @@ module SolidusSubscriptions
     #
     # @return [Boolean]
     def unfulfilled?
-      order_id.nil? || !order.completed?
+      !fulfilled?
     end
 
     # Had this installment been fulfilled by a completed order
     #
     # @return [Boolean]
     def fulfilled?
-      !unfulfilled?
+      details.joins(:order).where.not(spree_orders: { completed_at: nil } ).exists?
     end
 
     # Mark this installment as having a failed payment

--- a/app/models/solidus_subscriptions/installment.rb
+++ b/app/models/solidus_subscriptions/installment.rb
@@ -44,11 +44,12 @@ module SolidusSubscriptions
     #
     # @return [SolidusSubscriptions::InstallmentDetail] The record of the
     #   successful processing attempt
-    def success!
+    def success!(order)
       update!(actionable_date: nil)
 
       details.create!(
         success: true,
+        order: order,
         message: I18n.t('solidus_subscriptions.installment_details.success')
       )
     end

--- a/app/models/solidus_subscriptions/installment.rb
+++ b/app/models/solidus_subscriptions/installment.rb
@@ -57,11 +57,12 @@ module SolidusSubscriptions
     #
     # @return [SolidusSubscriptions::InstallmentDetail] The record of the
     #   failed processing attempt
-    def failed
+    def failed!(order)
       advance_actionable_date!
 
       details.create!(
         success: false,
+        order: order,
         message: I18n.t('solidus_subscriptions.installment_details.failed')
       )
     end

--- a/app/models/solidus_subscriptions/installment_detail.rb
+++ b/app/models/solidus_subscriptions/installment_detail.rb
@@ -8,6 +8,8 @@ module SolidusSubscriptions
       inverse_of: :details
     )
 
+    belongs_to(:order, class_name: 'Spree::Order')
+
     validates :installment, presence: true
     alias_attribute :successful, :success
 

--- a/app/models/solidus_subscriptions/payment_failed_dispatcher.rb
+++ b/app/models/solidus_subscriptions/payment_failed_dispatcher.rb
@@ -4,6 +4,9 @@
 module SolidusSubscriptions
   class PaymentFailedDispatcher < Dispatcher
     def dispatch
+      order.touch :completed_at
+      order.cancel!
+
       installments.each { |i| i.payment_failed!(order) }
       super
     end

--- a/app/models/solidus_subscriptions/payment_failed_dispatcher.rb
+++ b/app/models/solidus_subscriptions/payment_failed_dispatcher.rb
@@ -4,7 +4,7 @@
 module SolidusSubscriptions
   class PaymentFailedDispatcher < Dispatcher
     def dispatch
-      installments.each(&:payment_failed!)
+      installments.each { |i| i.payment_failed!(order) }
       super
     end
 

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -24,7 +24,7 @@ module SolidusSubscriptions
     # Find all subscriptions that are "actionable"; that is, ones that have an
     # actionable_date in the past and are not invalid or canceled.
     scope :actionable, (lambda do
-      where("#{table_name}.actionable_date < ?", Time.zone.now).
+      where("#{table_name}.actionable_date <= ?", Time.zone.now).
         where.not(state: ["canceled", "inactive"])
     end)
 

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -39,9 +39,10 @@ module SolidusSubscriptions
     scope :in_processing_state, (lambda do |state|
       case state.to_sym
       when :success
-        joins(installments: :order)
+        joins(installments: { details: :order }).where.not(spree_orders: { completed_at: nil })
       when :failed
-        joins(:installments).includes(installments: :order).where(spree_orders: { id: nil })
+        fulfilled_ids = joins(installments: { details: :order }).where.not(spree_orders: { completed_at: nil }).pluck(:id)
+        joins(:installments).where.not(solidus_subscriptions_subscriptions: { id: fulfilled_ids })
       when :pending
         includes(:installments).where(solidus_subscriptions_installments: { id: nil })
       else

--- a/app/models/solidus_subscriptions/subscription_order_promotion_rule.rb
+++ b/app/models/solidus_subscriptions/subscription_order_promotion_rule.rb
@@ -19,7 +19,7 @@ module SolidusSubscriptions
     #
     # @return [Boolean]
     def eligible?(order, **_options)
-      Installment.exists?(order: order)
+      order.subscription_order?
     end
   end
 end

--- a/app/models/solidus_subscriptions/success_dispatcher.rb
+++ b/app/models/solidus_subscriptions/success_dispatcher.rb
@@ -3,7 +3,7 @@
 module SolidusSubscriptions
   class SuccessDispatcher < Dispatcher
     def dispatch
-      installments.each(&:success!)
+      installments.each { |i| i.success!(order) }
       super
     end
 

--- a/db/migrate/20161017155749_add_order_id_to_solidus_subscriptions_installment_details.rb
+++ b/db/migrate/20161017155749_add_order_id_to_solidus_subscriptions_installment_details.rb
@@ -1,0 +1,6 @@
+class AddOrderIdToSolidusSubscriptionsInstallmentDetails < ActiveRecord::Migration
+  def change
+    add_reference :solidus_subscriptions_installment_details, :order, index: true
+    add_foreign_key :solidus_subscriptions_installment_details, :spree_orders, column: :order_id
+  end
+end

--- a/db/migrate/20161017175509_remove_order_id_from_solidus_subscriptions_installments.rb
+++ b/db/migrate/20161017175509_remove_order_id_from_solidus_subscriptions_installments.rb
@@ -1,0 +1,6 @@
+class RemoveOrderIdFromSolidusSubscriptionsInstallments < ActiveRecord::Migration
+  def change
+    remove_foreign_key :solidus_subscriptions_installments, column: :order_id
+    remove_column :solidus_subscriptions_installments, :order_id, :integer
+  end
+end

--- a/db/migrate/20161017201944_add_subscription_order_to_spree_orders.rb
+++ b/db/migrate/20161017201944_add_subscription_order_to_spree_orders.rb
@@ -1,0 +1,5 @@
+class AddSubscriptionOrderToSpreeOrders < ActiveRecord::Migration
+  def change
+    add_column :spree_orders, :subscription_order, :boolean, default: false, null: false
+  end
+end

--- a/lib/solidus_subscriptions/config.rb
+++ b/lib/solidus_subscriptions/config.rb
@@ -80,8 +80,9 @@ module SolidusSubscriptions
         ]
       end
 
-      def default_gateway
-        block_given? ? @gateway = Proc.new : @gateway.call
+      def default_gateway(&block)
+        return @gateway.call unless block_given?
+        @gateway = block
       end
     end
   end

--- a/lib/solidus_subscriptions/testing_support/factories/installment_factory.rb
+++ b/lib/solidus_subscriptions/testing_support/factories/installment_factory.rb
@@ -9,8 +9,13 @@ FactoryGirl.define do
     end
 
     trait :success do
-      order { create :completed_order_with_totals }
-      details { build_list(:installment_detail, 1, :success, installment: @instance) }
+      transient do
+        order { create :completed_order_with_totals }
+      end
+
+      details do
+        build_list(:installment_detail, 1, :success, installment: @instance, order: order)
+      end
     end
   end
 end

--- a/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
+++ b/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
@@ -66,9 +66,9 @@ RSpec.describe SolidusSubscriptions::ConsolidatedInstallment do
 
       it { is_expected.to be_complete }
 
-      it 'associates the order to the installments' do
+      it 'associates the order to the installment detail' do
         order
-        installment_orders = installments.map { |i| i.reload.order }.compact
+        installment_orders = installments.flat_map { |i| i.details.map(&:order) }.compact
         expect(installment_orders).to all eq order
       end
 

--- a/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
+++ b/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
@@ -189,10 +189,6 @@ RSpec.describe SolidusSubscriptions::ConsolidatedInstallment do
         )
       end
 
-      it 'creates no order' do
-        expect { subject }.to_not change { Spree::Order.count }
-      end
-
       it 'marks the installment to be reprocessed' do
         subject
         actionable_dates = installments.map do |installment|
@@ -247,11 +243,6 @@ RSpec.describe SolidusSubscriptions::ConsolidatedInstallment do
         end
 
         expect(actionable_dates).to all eq expected_date
-      end
-
-      it 'creates no orders' do
-        expect { subject }.to raise_error('arbitrary runtime error').
-          and change { Spree::Order.count }.by(0)
       end
     end
 

--- a/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
+++ b/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe SolidusSubscriptions::ConsolidatedInstallment do
       end
 
       it 'advances the installment actionable dates', :aggregate_failures do
-        expect { subject }. to raise_error('arbitrary runtime error')
+        expect { subject }.to raise_error('arbitrary runtime error')
 
         actionable_dates = installments.map do |installment|
           installment.reload.actionable_date

--- a/spec/models/solidus_subscriptions/failure_dispatcher_spec.rb
+++ b/spec/models/solidus_subscriptions/failure_dispatcher_spec.rb
@@ -1,8 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe SolidusSubscriptions::FailureDispatcher do
-  let(:dispatcher) { described_class.new(installments) }
+  let(:dispatcher) { described_class.new(installments, order) }
   let(:installments) { build_list(:installment, 2) }
+
+  let(:order) { create :order_with_line_items }
 
   describe '#dispatch' do
     subject { dispatcher.dispatch }
@@ -15,6 +17,10 @@ RSpec.describe SolidusSubscriptions::FailureDispatcher do
     it 'logs the failure' do
       expect(dispatcher).to receive(:notify).once
       subject
+    end
+
+    it 'cancels the order' do
+      expect { subject }.to change { order.state }.to 'canceled'
     end
   end
 end

--- a/spec/models/solidus_subscriptions/failure_dispatcher_spec.rb
+++ b/spec/models/solidus_subscriptions/failure_dispatcher_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SolidusSubscriptions::FailureDispatcher do
     subject { dispatcher.dispatch }
 
     it 'marks all the installments out of stock' do
-      expect(installments).to all receive(:failed).once
+      expect(installments).to all receive(:failed!).once
       subject
     end
 

--- a/spec/models/solidus_subscriptions/installment_detail_spec.rb
+++ b/spec/models/solidus_subscriptions/installment_detail_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe SolidusSubscriptions::InstallmentDetail, type: :model do
   it { is_expected.to belong_to :installment }
+  it { is_expected.to belong_to :order }
 
   it { is_expected.to validate_presence_of :installment }
 

--- a/spec/models/solidus_subscriptions/installment_spec.rb
+++ b/spec/models/solidus_subscriptions/installment_spec.rb
@@ -41,7 +41,9 @@ RSpec.describe SolidusSubscriptions::Installment, type: :model do
   end
 
   describe '#success!' do
-    subject { installment.success! }
+    subject { installment.success!(order) }
+
+    let(:order) { create :order }
 
     let(:installment) { create :installment, actionable_date: actionable_date }
     let(:actionable_date) { 1.month.from_now.to_date }
@@ -61,6 +63,7 @@ RSpec.describe SolidusSubscriptions::Installment, type: :model do
     it 'creates a successful installment detail' do
       subject
       expect(installment.details.last).to be_successful && have_attributes(
+        order: order,
         message: I18n.t('solidus_subscriptions.installment_details.success')
       )
     end
@@ -92,7 +95,12 @@ RSpec.describe SolidusSubscriptions::Installment, type: :model do
 
   describe '#unfulfilled?' do
     subject { installment.unfulfilled? }
-    let(:installment) { create(:installment, order: order) }
+    let(:installment) do
+      create(
+        :installment,
+        details: build_list(:installment_detail, 1, order: order)
+      )
+    end
 
     context 'the installment has an associated completed order' do
       let(:order) { create :completed_order_with_totals }
@@ -107,7 +115,12 @@ RSpec.describe SolidusSubscriptions::Installment, type: :model do
 
   describe '#fulfilled' do
     subject { installment.fulfilled? }
-    let(:installment) { create(:installment, order: order) }
+    let(:installment) do
+      create(
+        :installment,
+        details: build_list(:installment_detail, 1, order: order)
+      )
+    end
 
     context 'the installment has an associated completed order' do
       let(:order) { create :completed_order_with_totals }

--- a/spec/models/solidus_subscriptions/installment_spec.rb
+++ b/spec/models/solidus_subscriptions/installment_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe SolidusSubscriptions::Installment, type: :model do
   it { is_expected.to have_many :details }
-  it { is_expected.to belong_to :order }
   it { is_expected.to belong_to :subscription }
 
   it { is_expected.to validate_presence_of :subscription }

--- a/spec/models/solidus_subscriptions/installment_spec.rb
+++ b/spec/models/solidus_subscriptions/installment_spec.rb
@@ -94,40 +94,30 @@ RSpec.describe SolidusSubscriptions::Installment, type: :model do
 
   describe '#unfulfilled?' do
     subject { installment.unfulfilled? }
-    let(:installment) do
-      create(
-        :installment,
-        details: build_list(:installment_detail, 1, order: order)
-      )
-    end
+    let(:installment) { create(:installment, details: details) }
 
-    context 'the installment has an associated completed order' do
-      let(:order) { create :completed_order_with_totals }
+    context 'the installment has an associated successful detail' do
+      let(:details) { create_list :installment_detail, 1, success: true }
       it { is_expected.to be_falsy }
     end
 
-    context 'the installment has no associated completed order' do
-      let(:order) { nil }
+    context 'the installment has no associated successful detail' do
+      let(:details) { create_list :installment_detail, 1 }
       it { is_expected.to be_truthy }
     end
   end
 
   describe '#fulfilled' do
     subject { installment.fulfilled? }
-    let(:installment) do
-      create(
-        :installment,
-        details: build_list(:installment_detail, 1, order: order)
-      )
-    end
+    let(:installment) { create(:installment, details: details) }
 
     context 'the installment has an associated completed order' do
-      let(:order) { create :completed_order_with_totals }
+      let(:details) { create_list :installment_detail, 1, success: true }
       it { is_expected.to be_truthy }
     end
 
     context 'the installment has no associated completed order' do
-      let(:order) { nil }
+      let(:details) { create_list :installment_detail, 1 }
       it { is_expected.to be_falsy }
     end
   end

--- a/spec/models/solidus_subscriptions/installment_spec.rb
+++ b/spec/models/solidus_subscriptions/installment_spec.rb
@@ -66,8 +66,9 @@ RSpec.describe SolidusSubscriptions::Installment, type: :model do
     end
   end
 
-  describe '#failed' do
-    subject { installment.failed }
+  describe '#failed!' do
+    subject { installment.failed!(order) }
+    let(:order) { create :order }
 
     let(:expected_date) do
       Date.current + SolidusSubscriptions::Config.reprocessing_interval
@@ -77,7 +78,8 @@ RSpec.describe SolidusSubscriptions::Installment, type: :model do
     it { is_expected.to_not be_successful }
     it 'has the correct message' do
       expect(subject).to have_attributes(
-        message: I18n.t('solidus_subscriptions.installment_details.failed')
+        message: I18n.t('solidus_subscriptions.installment_details.failed'),
+        order: order
       )
     end
 

--- a/spec/models/solidus_subscriptions/installment_spec.rb
+++ b/spec/models/solidus_subscriptions/installment_spec.rb
@@ -121,7 +121,9 @@ RSpec.describe SolidusSubscriptions::Installment, type: :model do
   end
 
   describe '#payment_failed!' do
-    subject { installment.payment_failed! }
+    subject { installment.payment_failed!(order) }
+
+    let(:order) { create :order }
 
     let(:expected_date) do
       Date.current + SolidusSubscriptions::Config.reprocessing_interval
@@ -131,6 +133,7 @@ RSpec.describe SolidusSubscriptions::Installment, type: :model do
     it { is_expected.to_not be_successful }
     it 'has the correct message' do
       expect(subject).to have_attributes(
+        order: order,
         message: I18n.t('solidus_subscriptions.installment_details.payment_failed')
       )
     end

--- a/spec/models/solidus_subscriptions/payment_failed_dispatcher_spec.rb
+++ b/spec/models/solidus_subscriptions/payment_failed_dispatcher_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe SolidusSubscriptions::PaymentFailedDispatcher do
-  let(:dispatcher) { described_class.new(installments) }
+  let(:dispatcher) { described_class.new(installments, order) }
   let(:installments) { build_list(:installment, 2) }
+  let(:order) { create :order_with_line_items }
 
   describe 'initialization' do
     subject { dispatcher }
@@ -20,6 +21,10 @@ RSpec.describe SolidusSubscriptions::PaymentFailedDispatcher do
     it 'logs the failure' do
       expect(dispatcher).to receive(:notify).once
       subject
+    end
+
+    it 'cancels the order' do
+      expect { subject }.to change { order.state }.to 'canceled'
     end
   end
 end

--- a/spec/models/solidus_subscriptions/subscription_order_promotion_rule_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_order_promotion_rule_spec.rb
@@ -19,14 +19,14 @@ RSpec.describe SolidusSubscriptions::SubscriptionOrderPromotionRule do
 
   describe '#eligible?' do
     subject { rule.eligible? order }
-    let(:order) { create(:order) }
 
     context 'when the order fulfills a subscription installment' do
-      let!(:installment) { create(:installment, order: order) }
+      let(:order) { create(:order, subscription_order: true) }
       it { is_expected.to be_truthy }
     end
 
     context 'when the order contains does not fulfill a subscription installment' do
+      let(:order) { create(:order) }
       it { is_expected.to be_falsy }
     end
   end

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
             :installment,
             1,
             :success,
-            details: build_list(:installment_detail, 1, order: order)
+            details: build_list(:installment_detail, 1, order: order, success: true)
           )
         )
       end

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -220,10 +220,17 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
     end
 
     context 'when the last processing attempt succeeded' do
+      let(:order) { create :completed_order_with_totals }
+
       let(:subscription) do
         create(
           :subscription,
-          installments: create_list(:installment, 1, :success)
+          installments: create_list(
+            :installment,
+            1,
+            :success,
+            details: build_list(:installment_detail, 1, order: order)
+          )
         )
       end
 


### PR DESCRIPTION
It was pointed out that if there is any error raised after the payment
is authorized, the transaction would roll back and we would have no
record of the authorization.

All installment details now have an associated order which is the order
resulting from that attempt at processing an installment. It can be
completed or not

The order for each processing attempt can now be inspected to see what went wrong. Installments now no longer track which spree order has fulfilled them directly 