### PR TITLE
Initialize the gateway with a block

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you would like to specify the gateway used by the gem you can add this to
 an initialzer.
 
 ```ruby
-SolidusSubscriptions::Config.default_gateway = my_gateway
+SolidusSubscriptions::Config.default_gateway { my_gateway }
 ```
 
 ## Usage

--- a/apidoc/configuration.md
+++ b/apidoc/configuration.md
@@ -8,7 +8,7 @@ behaviour of the gem:
 
 # The gateway the `ConsolidatedInstallment` will use when charging recurring
 # orders. We highly recommend setting this to a specific value
-SolidusSubscriptions::Config.default_gateway = my_gateway
+SolidusSubscriptions::Config.default_gateway { my_gateway }
 
 # Defines how long the system will wait before allowing a failed installment to
 # be reprocessed by the `Processor`

--- a/lib/solidus_subscriptions/config.rb
+++ b/lib/solidus_subscriptions/config.rb
@@ -80,28 +80,8 @@ module SolidusSubscriptions
         ]
       end
 
-      def default_gateway=(gateway)
-        @gateway = gateway
-      end
-
       def default_gateway
-        @gateway ||= Spree::Gateway.where(active: true).detect do |gateway|
-          gateway.payment_source_class == Spree::CreditCard
-        end
-
-        return @gateway if @gateway
-
-        raise <<-MSG.strip
-          SolidusSubscriptions requires a Credit Card Gateway
-
-          Make sure at lease one Spree::PaymentMethod exists with a
-          #payment_source_class of Spree::CreditCard.
-
-          Alternatively, you can manually set the Gateway you would like to use by
-          adding the following to an initializer:
-
-          SolidusSubscription::Config.default_gateway = my_gateway
-        MSG
+        block_given? ? @gateway = Proc.new : @gateway.call
       end
     end
   end

--- a/spec/helpers/checkout_infrastructure.rb
+++ b/spec/helpers/checkout_infrastructure.rb
@@ -6,11 +6,13 @@ module CheckoutInfrastructure
       create :credit_card_payment_method
       create :country
       create :shipping_method
+
+      SolidusSubscriptions::Config.default_gateway { Spree::Gateway::Bogus.last }
     end
 
     base.after(:all) do
       DatabaseCleaner.clean_with(:truncation)
-      SolidusSubscriptions::Config.default_gateway = nil
+      SolidusSubscriptions::Config.default_gateway { nil }
     end
   end
 end

--- a/spec/lib/solidus_subscriptions/config_spec.rb
+++ b/spec/lib/solidus_subscriptions/config_spec.rb
@@ -5,38 +5,13 @@ RSpec.describe SolidusSubscriptions::Config do
   after { described_class.instance_variable_set('@gateway', nil) }
 
   describe '.default_gateway' do
-    subject(:gateway) { described_class.default_gateway }
     let(:bogus) { build_stubbed(:credit_card_payment_method) }
+    subject(:gateway) { described_class.default_gateway }
 
-    context 'there is a gateway set' do
-      before { described_class.instance_variable_set('@gateway', bogus) }
-      it { is_expected.to eq bogus }
+    before do
+      described_class.default_gateway { bogus }
     end
 
-    context 'there is no gateway set, but a gateway exists' do
-      before { create(:credit_card_payment_method) }
-
-      it 'gets the last credit card gateway' do
-        expect(gateway).to eq(Spree::Gateway.last).and have_attributes(
-          payment_source_class: Spree::CreditCard
-        )
-      end
-    end
-
-    context 'no gateway exists' do
-      it 'raises a friendly error' do
-        expect { subject }.to raise_error RuntimeError, /requires a Credit Card/
-      end
-    end
-  end
-
-  describe 'default_gateway=' do
-    subject(:gateway) { described_class.default_gateway = value }
-    let(:value) { 'test123' }
-
-    it 'sets the correct instance variable' do
-      subject
-      expect(described_class.instance_variable_get('@gateway')).to eq value
-    end
+    it { is_expected.to eq bogus }
   end
 end


### PR DESCRIPTION
So Ive been running into the problem of the gateway being evaluated too
early (before the db is created) having it be explicitely set in an
initializer.

Im now specifying the default gateway in a block so that it will not be
evaluated until it is actually needed