### PR TITLE
make_subs_permitted_attriubtes_configurable

### DIFF
--- a/apidoc/configuration.md
+++ b/apidoc/configuration.md
@@ -45,6 +45,11 @@ SolidusSubscriptions::Config.subscription_line_item_attributes = [
   :max_installments
 ]
 
+# SolidusSubscriptions::Subscription attributes which are allowed to
+# be updated from user data
+
+SolidusSubscriptions::Config.subscription_attributes = [:actionable_date]
+
 # Dispatchers (processing callbacks)
 
 # These handlers are pluggable, however it is highly encouraged that you

--- a/lib/solidus_subscriptions/config.rb
+++ b/lib/solidus_subscriptions/config.rb
@@ -80,6 +80,10 @@ module SolidusSubscriptions
         ]
       end
 
+      # SolidusSubscriptions::Subscription attributes which are allowed to
+      # be updated from user data
+      mattr_accessor(:subscription_attributes) { [:actionable_date] }
+
       def default_gateway(&block)
         return @gateway.call unless block_given?
         @gateway = block

--- a/lib/solidus_subscriptions/permitted_attributes.rb
+++ b/lib/solidus_subscriptions/permitted_attributes.rb
@@ -21,7 +21,7 @@ module SolidusSubscriptions
       end
 
       def subscription_attributes
-        [
+        Config.subscription_attributes | [
           { line_item_attributes: nested(subscription_line_item_attributes) - [:subscribable_id] }
         ]
       end
@@ -29,7 +29,7 @@ module SolidusSubscriptions
       private
 
       def nested(attributes)
-        attributes << :id
+        attributes | [:id]
       end
     end
   end


### PR DESCRIPTION
Allow the Subscription permitted attributes to be configurable from an initializer. 

By default, Subscriptions now accept the actionable date as a permitted attribute