### PR TITLE
Fix spec failures

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,8 +9,6 @@ begin
 
   RSpec::Core::RakeTask.new(:spec)
 
-  RuboCop::RakeTask.new
-
   task default: %i(first_run rubocop spec)
 rescue LoadError
   # no rspec available

--- a/app/models/solidus_subscriptions/order_builder.rb
+++ b/app/models/solidus_subscriptions/order_builder.rb
@@ -32,7 +32,7 @@ module SolidusSubscriptions
 
       if line_item
         line_item.quantity += new_item.quantity
-        line_item
+        line_item.tap(&:save!)
       else
         order.line_items << new_item
       end

--- a/spec/models/solidus_subscriptions/order_builder_spec.rb
+++ b/spec/models/solidus_subscriptions/order_builder_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SolidusSubscriptions::OrderBuilder do
 
     let(:variant) { create :variant, subscribable: true }
     let(:order) do
-      build_stubbed :order, line_items_attributes: line_items_attributes
+      create :order, line_items_attributes: line_items_attributes
     end
 
     let(:line_item) { create(:line_item, quantity: 4, variant: variant) }
@@ -45,7 +45,7 @@ RSpec.describe SolidusSubscriptions::OrderBuilder do
         existing_line_item = order.line_items.first
 
         expect { subject }.
-          to change { existing_line_item.quantity }.
+          to change { existing_line_item.reload.quantity }.
           by(line_item.quantity)
       end
     end


### PR DESCRIPTION
Not really sure how this was correct before.

When the line item already existed on an order, the builder would
increment the quantity of the line item without saving it. in the specs,
a different instance of the line item would be tested resulting in the
change in quantity not being apparent to the spec