### PR TITLE
Remove root order

### DIFF
--- a/app/models/solidus_subscriptions/consolidated_installment.rb
+++ b/app/models/solidus_subscriptions/consolidated_installment.rb
@@ -8,7 +8,7 @@ module SolidusSubscriptions
     #   when generating a new order
     attr_reader :installments
 
-    delegate :user, :root_order, to: :subscription
+    delegate :user, to: :subscription
 
     # Get a new instance of a ConsolidatedInstallment
     #
@@ -117,11 +117,11 @@ module SolidusSubscriptions
     end
 
     def ship_address
-      user.ship_address || root_order.ship_address
+      user.ship_address
     end
 
     def active_card
-      user.credit_cards.default.last || root_order.credit_cards.last
+      user.credit_cards.default.last
     end
 
     def create_payment

--- a/app/models/solidus_subscriptions/consolidated_installment.rb
+++ b/app/models/solidus_subscriptions/consolidated_installment.rb
@@ -57,7 +57,7 @@ module SolidusSubscriptions
       @order ||= Spree::Order.create(
         user: user,
         email: user.email,
-        store: root_order.try!(:store) || Spree::Store.default,
+        store: subscription.store || Spree::Store.default,
         subscription_order: true
       )
     end

--- a/app/models/solidus_subscriptions/order_builder.rb
+++ b/app/models/solidus_subscriptions/order_builder.rb
@@ -31,8 +31,7 @@ module SolidusSubscriptions
       end
 
       if line_item
-        line_item.quantity += new_item.quantity
-        line_item.tap(&:save!)
+        line_item.increment!(:quantity, new_item.quantity)
       else
         order.line_items << new_item
       end

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -9,6 +9,7 @@ module SolidusSubscriptions
     has_one :line_item, class_name: 'SolidusSubscriptions::LineItem'
     has_many :installments, class_name: 'SolidusSubscriptions::Installment'
     has_one :root_order, through: :line_item, class_name: 'Spree::Order', source: :order
+    belongs_to :store, class_name: 'Spree::Store'
 
     validates :user, presence: :true
     validates :skip_count, :successive_skip_count, presence: true, numericality: { greater_than_or_equal_to: 0 }

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -8,7 +8,6 @@ module SolidusSubscriptions
     belongs_to :user, class_name: Spree.user_class
     has_one :line_item, class_name: 'SolidusSubscriptions::LineItem'
     has_many :installments, class_name: 'SolidusSubscriptions::Installment'
-    has_one :root_order, through: :line_item, class_name: 'Spree::Order', source: :order
     belongs_to :store, class_name: 'Spree::Store'
 
     validates :user, presence: :true

--- a/app/models/solidus_subscriptions/subscription_generator.rb
+++ b/app/models/solidus_subscriptions/subscription_generator.rb
@@ -11,8 +11,9 @@ module SolidusSubscriptions
     def self.activate(subscription_line_items)
       subscription_line_items.map do |subscription_line_item|
         user = subscription_line_item.order.user
+        store = subscription_line_item.order.store
 
-        Subscription.create!(user: user, line_item: subscription_line_item) do |sub|
+        Subscription.create!(user: user, line_item: subscription_line_item, store: store) do |sub|
           sub.actionable_date = sub.next_actionable_date
         end
       end

--- a/db/migrate/20161221155142_add_store_to_solidus_subscriptions_subscriptions.rb
+++ b/db/migrate/20161221155142_add_store_to_solidus_subscriptions_subscriptions.rb
@@ -1,0 +1,6 @@
+class AddStoreToSolidusSubscriptionsSubscriptions < ActiveRecord::Migration
+  def change
+    add_reference :solidus_subscriptions_subscriptions, :store, index: true
+    add_foreign_key :solidus_subscriptions_subscriptions, :spree_stores, column: :store_id
+  end
+end

--- a/lib/solidus_subscriptions/testing_support/factories/spree_modification_factory.rb
+++ b/lib/solidus_subscriptions/testing_support/factories/spree_modification_factory.rb
@@ -1,0 +1,8 @@
+FactoryGirl.modify do
+  factory :user do
+    trait :subscription_user do
+      bill_address
+      ship_address
+    end
+  end
+end

--- a/lib/solidus_subscriptions/testing_support/factories/subscription_factory.rb
+++ b/lib/solidus_subscriptions/testing_support/factories/subscription_factory.rb
@@ -1,5 +1,7 @@
 FactoryGirl.define do
   factory :subscription, class: 'SolidusSubscriptions::Subscription' do
+    store
+
     user do
       ccs = build_list(:credit_card, 1, gateway_customer_profile_id: 'BGS-123', default: true)
       build :user, credit_cards: ccs

--- a/lib/solidus_subscriptions/testing_support/factories/subscription_factory.rb
+++ b/lib/solidus_subscriptions/testing_support/factories/subscription_factory.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
 
     user do
       ccs = build_list(:credit_card, 1, gateway_customer_profile_id: 'BGS-123', default: true)
-      build :user, credit_cards: ccs
+      build :user, :subscription_user, credit_cards: ccs
     end
 
     trait :with_line_item do

--- a/spec/lib/solidus_subscriptions/processor_spec.rb
+++ b/spec/lib/solidus_subscriptions/processor_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe SolidusSubscriptions::Processor, :checkout do
   let(:user) do
     ccs = build_list(:credit_card, 1, gateway_customer_profile_id: 'BGS-123', default: true)
-    build :user, credit_cards: ccs
+    build :user, :subscription_user, credit_cards: ccs
   end
 
   let!(:actionable_subscriptions) { create_list(:subscription, 2, :actionable, user: user) }

--- a/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
+++ b/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
@@ -266,7 +266,7 @@ RSpec.describe SolidusSubscriptions::ConsolidatedInstallment do
       expect(subject).to have_attributes(
         user: user,
         email: user.email,
-        store: root_order.store
+        store: installments.first.subscription.store
       )
     end
 

--- a/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
+++ b/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
@@ -2,16 +2,15 @@ require 'rails_helper'
 
 RSpec.describe SolidusSubscriptions::ConsolidatedInstallment do
   let(:consolidated_installment) { described_class.new(installments) }
-  let(:root_order) { create :completed_order_with_pending_payment }
-  let(:subscription_user) { create :user }
+
+  let(:subscription_user) do
+    ccs = build_list(:credit_card, 1, gateway_customer_profile_id: 'BGS-123', default: true)
+    create :user, :subscription_user, credit_cards: ccs
+  end
+
   let(:installments) do
     traits = {
-      subscription_traits: [{
-        user: subscription_user,
-        line_item_traits: [{
-          spree_line_item: root_order.line_items.first
-        }]
-      }]
+      subscription_traits: [{ user: subscription_user }]
     }
 
     create_list(:installment, 2, traits)
@@ -98,39 +97,6 @@ RSpec.describe SolidusSubscriptions::ConsolidatedInstallment do
 
       it 'creates no order' do
         expect { subject }.to_not change { Spree::Order.count }
-      end
-    end
-
-    context 'the user has addresss and active card' do
-      let(:credit_card) { create(:credit_card, gateway_customer_profile_id: 'BGS-123', default: true) }
-
-      before do
-        consolidated_installment.user.credit_cards << credit_card
-        consolidated_installment.user.update ship_address: create(:address)
-      end
-
-      it_behaves_like 'a completed checkout'
-
-      it 'uses the root order address' do
-        expect(order.ship_address).to eq consolidated_installment.user.ship_address
-      end
-
-      it 'uses the root orders last payment method' do
-        source = order.payments.last.source
-        expect(source).to eq credit_card
-      end
-    end
-
-    context 'the user has no address or active card' do
-      it_behaves_like 'a completed checkout'
-
-      it 'uses the root order address' do
-        expect(order.ship_address).to eq consolidated_installment.root_order.ship_address
-      end
-
-      it 'uses the root orders last payment method' do
-        source = order.payments.last.source
-        expect(source).to eq consolidated_installment.root_order.payments.last.source
       end
     end
 

--- a/spec/models/solidus_subscriptions/subscription_generator_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_generator_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe SolidusSubscriptions::SubscriptionGenerator do
     let(:subscription_line_items) { build_list :subscription_line_item, 1 }
     let(:subscription_line_item) { subscription_line_items.first }
     let(:user) { subscription_line_items.first.order.user }
+    let(:store) { subscription_line_items.first.order.store }
 
     it { is_expected.to be_a Array }
 
@@ -20,7 +21,8 @@ RSpec.describe SolidusSubscriptions::SubscriptionGenerator do
       subscription = subject.first
       expect(subscription).to have_attributes(
         user: user,
-        line_item: subscription_line_item
+        line_item: subscription_line_item,
+        store: store
       )
     end
   end

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe SolidusSubscriptions::Subscription, type: :model do
   it { is_expected.to have_many :installments }
   it { is_expected.to belong_to :user }
+  it { is_expected.to belong_to :store }
   it { is_expected.to have_one :line_item }
 
   it { is_expected.to validate_presence_of :user }


### PR DESCRIPTION
The root order was a concept used as a fallback for shipping addresses and payment methods when creating subscription orders.

It relied on a 1 - 1 relationship between the subscription and a subscription line item. 

This is something we have decided to change in order to support subscriptions with multiple subscription line items. 

Given a subscription must have a user  (and in future we should validate that that user has a ship address and payment method). We will always grab the ship address and payment method from the user.

We will store the spree_store on the subscription when it is created. 


Existing stores will want to add this migration after dropping the `root_order` relationship

```ruby
class PopulateSubscriptionStoreIds < ActiveRecord::Migration
  def change
    q = <<-SQL
      UPDATE solidus_subscriptions_subscriptions
      SET
        store_id = (
          SELECT spree_orders.store_id
          FROM solidus_subscriptions_subscriptions AS subs
          INNER JOIN solidus_subscriptions_line_items ON
            solidus_subscriptions_line_items.subscription_id = solidus_subscriptions_subscriptions.id
          INNER JOIN spree_line_items ON
            solidus_subscriptions_line_items.spree_line_item_id = spree_line_items.id
          INNER JOIN spree_orders ON
            spree_line_items.order_id = spree_orders.id
          WHERE
            solidus_subscriptions_subscriptions.id = subs.id
        )
    SQL

    ActiveRecord::Base.connection.execute(q)
  end
end
````