### PR TITLE
Line item builder accepts a collection of line items

### DIFF
--- a/app/models/solidus_subscriptions/consolidated_installment.rb
+++ b/app/models/solidus_subscriptions/consolidated_installment.rb
@@ -85,17 +85,13 @@ module SolidusSubscriptions
     def populate
       unfulfilled_installments = []
 
-      line_items = installments.map do |installment|
-        line_item = installment.line_item_builder.line_item
+      order_line_items = installments.flat_map do |installment|
+        line_items = installment.line_item_builder.spree_line_items
 
-        if line_item.nil?
-          unfulfilled_installments << installment
-          next
-        end
+        unfulfilled_installments.push(installment) if line_items.empty?
 
-        line_item
-      end.
-      compact
+        line_items
+      end
 
       # Remove installments which had no stock from the active list
       # They will be reprocessed later
@@ -105,7 +101,7 @@ module SolidusSubscriptions
       end
 
       return if installments.empty?
-      order_builder.add_line_items(line_items)
+      order_builder.add_line_items(order_line_items)
     end
 
     def order_builder

--- a/app/models/solidus_subscriptions/line_item.rb
+++ b/app/models/solidus_subscriptions/line_item.rb
@@ -57,12 +57,12 @@ module SolidusSubscriptions
     # Get a placeholder line item for calculating the values of future
     # subscription orders. It is frozen and cannot be saved
     def dummy_line_item
-      dummy_subscription.line_item_builder.line_item.tap do |li|
-        next unless li
-        li.order = dummy_order
-        li.validate
-      end.
-      freeze
+      li = LineItemBuilder.new([self]).spree_line_items.first
+      return unless li
+
+      li.order = dummy_order
+      li.validate
+      li.freeze
     end
 
     private

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -173,7 +173,7 @@ module SolidusSubscriptions
     #
     # @return [SolidusSubscriptions::LineItemBuilder]
     def line_item_builder
-      LineItemBuilder.new(line_item)
+      LineItemBuilder.new([line_item])
     end
 
     # The state of the last attempt to process an installment associated to

--- a/spec/models/solidus_subscriptions/installment_spec.rb
+++ b/spec/models/solidus_subscriptions/installment_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SolidusSubscriptions::Installment, type: :model do
     let(:line_item) { installment.subscription.line_item }
 
     it { is_expected.to be_a SolidusSubscriptions::LineItemBuilder }
-    it { is_expected.to have_attributes(subscription_line_item: line_item) }
+    it { is_expected.to have_attributes(subscription_line_items: [line_item]) }
   end
 
   describe '#out_of_stock' do

--- a/spec/models/solidus_subscriptions/line_item_builder_spec.rb
+++ b/spec/models/solidus_subscriptions/line_item_builder_spec.rb
@@ -1,14 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe SolidusSubscriptions::LineItemBuilder do
-  let(:builder) { described_class.new subscription_line_item }
+  let(:builder) { described_class.new subscription_line_items }
   let(:variant) { create(:variant, subscribable: true) }
-  let(:subscription_line_item) do
-    build_stubbed(:subscription_line_item, subscribable_id: variant.id)
+  let(:subscription_line_item) { subscription_line_items.first }
+  let(:subscription_line_items) do
+    build_stubbed_list(:subscription_line_item, 1, subscribable_id: variant.id)
   end
 
-  describe '#line_item' do
-    subject { builder.line_item }
+  describe '#spree_line_items' do
+    subject { builder.spree_line_items }
     let(:expected_attributes) do
       {
         variant_id: subscription_line_item.subscribable_id,
@@ -16,8 +17,11 @@ RSpec.describe SolidusSubscriptions::LineItemBuilder do
       }
     end
 
-    it { is_expected.to be_a Spree::LineItem }
-    it { is_expected.to have_attributes expected_attributes }
+    it { is_expected.to be_a Array }
+
+    it 'contains a line item with the correct attributes' do
+      expect(subject.first).to have_attributes expected_attributes
+    end
 
     context 'the variant is not subscribable' do
       let!(:variant) { create(:variant) }
@@ -32,7 +36,7 @@ RSpec.describe SolidusSubscriptions::LineItemBuilder do
 
     context 'the variant is out of stock' do
       before { create :stock_location, backorderable_default: false }
-      it { is_expected.to be_nil }
+      it { is_expected.to be_empty }
     end
   end
 end

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
     let(:line_item) { subscription.line_item }
 
     it { is_expected.to be_a SolidusSubscriptions::LineItemBuilder }
-    it { is_expected.to have_attributes(subscription_line_item: line_item) }
+    it { is_expected.to have_attributes(subscription_line_items: [line_item]) }
   end
 
   describe '#processing_state' do


### PR DESCRIPTION
In preparation of moving to subscriptions supporting multiple
subscription line items. The line item builder needs to be updated to
accept a collection of line items.