### PR TITLE
Subscriptions support multiple subscription_line_items

### DIFF
--- a/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
+++ b/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
@@ -3,7 +3,7 @@ class SolidusSubscriptions::Api::V1::SubscriptionsController < Spree::Api::BaseC
 
   def update
     if @subscription.update(subscription_params)
-      render json: @subscription.to_json(include: :line_item)
+      render json: @subscription.to_json(include: :line_items)
     else
       render json: @subscription.errors.to_json, status: 422
     end
@@ -33,7 +33,7 @@ class SolidusSubscriptions::Api::V1::SubscriptionsController < Spree::Api::BaseC
 
   def subscription_params
     params.require(:subscription).permit(
-      line_item_attributes: line_item_attributes
+      line_items_attributes: line_item_attributes
     )
   end
 

--- a/app/controllers/spree/admin/subscriptions_controller.rb
+++ b/app/controllers/spree/admin/subscriptions_controller.rb
@@ -8,14 +8,14 @@ module Spree
           accessible_by(current_ability, :index).ransack(params[:q])
 
         @subscriptions = @search.result(distinct: true).
-          includes(:line_item, :user).
-          joins(:line_item, :user).
+          includes(:line_items, :user).
+          joins(:line_items, :user).
           page(params[:page]).
           per(params[:per_page] || Spree::Config[:orders_per_page])
       end
 
       def new
-        @subscription.build_line_item
+        @subscription.line_items.new
       end
 
       def cancel

--- a/app/models/solidus_subscriptions/consolidated_installment.rb
+++ b/app/models/solidus_subscriptions/consolidated_installment.rb
@@ -85,17 +85,13 @@ module SolidusSubscriptions
     def populate
       unfulfilled_installments = []
 
-      line_items = installments.map do |installment|
-        line_item = installment.line_item_builder.line_item
+      order_line_items = installments.flat_map do |installment|
+        line_items = installment.line_item_builder.spree_line_items
 
-        if line_item.nil?
-          unfulfilled_installments << installment
-          next
-        end
+        unfulfilled_installments.push(installment) if line_items.empty?
 
-        line_item
-      end.
-      compact
+        line_items
+      end
 
       # Remove installments which had no stock from the active list
       # They will be reprocessed later
@@ -105,7 +101,7 @@ module SolidusSubscriptions
       end
 
       return if installments.empty?
-      order_builder.add_line_items(line_items)
+      order_builder.add_line_items(order_line_items)
     end
 
     def order_builder

--- a/app/models/solidus_subscriptions/line_item.rb
+++ b/app/models/solidus_subscriptions/line_item.rb
@@ -22,7 +22,7 @@ module SolidusSubscriptions
     belongs_to(
       :subscription,
       class_name: 'SolidusSubscriptions::Subscription',
-      inverse_of: :line_item
+      inverse_of: :line_items
     )
 
     enum interval_units: {
@@ -81,7 +81,7 @@ module SolidusSubscriptions
     # A place holder for calculating dynamic values needed to display in the cart
     # it is frozen and cannot be saved
     def dummy_subscription
-      Subscription.new(line_item: dup).freeze
+      Subscription.new(line_items: [dup]).freeze
     end
 
     def update_actionable_date_if_interval_changed

--- a/app/models/solidus_subscriptions/line_item.rb
+++ b/app/models/solidus_subscriptions/line_item.rb
@@ -57,12 +57,12 @@ module SolidusSubscriptions
     # Get a placeholder line item for calculating the values of future
     # subscription orders. It is frozen and cannot be saved
     def dummy_line_item
-      dummy_subscription.line_item_builder.line_item.tap do |li|
-        next unless li
-        li.order = dummy_order
-        li.validate
-      end.
-      freeze
+      li = LineItemBuilder.new([self]).spree_line_items.first
+      return unless li
+
+      li.order = dummy_order
+      li.validate
+      li.freeze
     end
 
     private

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -6,14 +6,14 @@ module SolidusSubscriptions
     PROCESSING_STATES = [:pending, :failed, :success]
 
     belongs_to :user, class_name: Spree.user_class
-    has_one :line_item, class_name: 'SolidusSubscriptions::LineItem'
+    has_many :line_items, class_name: 'SolidusSubscriptions::LineItem'
     has_many :installments, class_name: 'SolidusSubscriptions::Installment'
     belongs_to :store, class_name: 'Spree::Store'
 
     validates :user, presence: :true
     validates :skip_count, :successive_skip_count, presence: true, numericality: { greater_than_or_equal_to: 0 }
 
-    accepts_nested_attributes_for :line_item
+    accepts_nested_attributes_for :line_items
 
     # The following methods are delegated to the associated
     # SolidusSubscriptions::LineItem
@@ -173,7 +173,7 @@ module SolidusSubscriptions
     #
     # @return [SolidusSubscriptions::LineItemBuilder]
     def line_item_builder
-      LineItemBuilder.new([line_item])
+      LineItemBuilder.new(line_items)
     end
 
     # The state of the last attempt to process an installment associated to
@@ -203,6 +203,10 @@ module SolidusSubscriptions
       if skip_count >= Config.maximum_total_skips
         errors.add(:skip_count, :exceeded)
       end
+    end
+
+    def line_item
+      line_items.first
     end
   end
 end

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -173,7 +173,7 @@ module SolidusSubscriptions
     #
     # @return [SolidusSubscriptions::LineItemBuilder]
     def line_item_builder
-      LineItemBuilder.new(line_item)
+      LineItemBuilder.new([line_item])
     end
 
     # The state of the last attempt to process an installment associated to

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -19,7 +19,7 @@ module SolidusSubscriptions
     # SolidusSubscriptions::LineItem
     #
     # :interval, :quantity, :subscribable_id, :max_installments
-    delegate :interval, :quantity, :subscribable_id, :max_installments, to: :line_item
+    delegate :interval, :max_installments, to: :line_item
 
     # Find all subscriptions that are "actionable"; that is, ones that have an
     # actionable_date in the past and are not invalid or canceled.

--- a/app/models/solidus_subscriptions/subscription_generator.rb
+++ b/app/models/solidus_subscriptions/subscription_generator.rb
@@ -2,20 +2,21 @@
 # objects and creating SolidusSubscriptions::Subscription Objects
 module SolidusSubscriptions
   module SubscriptionGenerator
-    # Create and persist a collection of subscriptions
+    # Create and persist a subscription for a collection of subscription
+    #   line items
     #
     # @param subscription_line_items [Array<SolidusSubscriptions::LineItem>] The
     #   subscription_line_items to be activated
     #
-    # @return [Array<SolidusSubscriptions::Subscription>]
+    # @return [SolidusSubscriptions::Subscription]
     def self.activate(subscription_line_items)
-      subscription_line_items.map do |subscription_line_item|
-        user = subscription_line_item.order.user
-        store = subscription_line_item.order.store
+      return if subscription_line_items.empty?
 
-        Subscription.create!(user: user, line_item: subscription_line_item, store: store) do |sub|
-          sub.actionable_date = sub.next_actionable_date
-        end
+      user = subscription_line_items.first.order.user
+      store = subscription_line_items.first.order.store
+
+      Subscription.create!(user: user, line_items: subscription_line_items, store: store) do |sub|
+        sub.actionable_date = sub.next_actionable_date
       end
     end
   end

--- a/lib/solidus_subscriptions/permitted_attributes.rb
+++ b/lib/solidus_subscriptions/permitted_attributes.rb
@@ -17,12 +17,12 @@ module SolidusSubscriptions
       end
 
       def subscription_line_item_attributes
-        Config.subscription_line_item_attributes
+        [Config.subscription_line_item_attributes]
       end
 
       def subscription_attributes
         Config.subscription_attributes | [
-          { line_item_attributes: nested(subscription_line_item_attributes) - [:subscribable_id] }
+          { line_items_attributes: nested(subscription_line_item_attributes) - [:subscribable_id] }
         ]
       end
 

--- a/lib/solidus_subscriptions/testing_support/factories/subscription_factory.rb
+++ b/lib/solidus_subscriptions/testing_support/factories/subscription_factory.rb
@@ -12,7 +12,7 @@ FactoryGirl.define do
         line_item_traits []
       end
 
-      line_item { build :subscription_line_item, *line_item_traits }
+      line_items { build_list :subscription_line_item, 1, *line_item_traits }
     end
 
     trait :actionable do

--- a/spec/controllers/solidus_subscriptions/api/v1/subscriptions_controller_spec.rb
+++ b/spec/controllers/solidus_subscriptions/api/v1/subscriptions_controller_spec.rb
@@ -43,10 +43,10 @@ RSpec.describe SolidusSubscriptions::Api::V1::SubscriptionsController, type: :co
 
     let(:subscription_params) do
       {
-        line_item_attributes: {
-          id: subscription.line_item.id,
+        line_items_attributes: [{
+          id: subscription.line_items.first.id,
           quantity: 6
-        }
+        }]
       }
     end
 
@@ -57,10 +57,10 @@ RSpec.describe SolidusSubscriptions::Api::V1::SubscriptionsController, type: :co
       context 'when the params are not valid' do
         let(:subscription_params) do
           {
-            line_item_attributes: {
-              id: subscription.line_item.id,
+            line_items_attributes: [{
+              id: subscription.line_items.first.id,
               quantity: -6
-            }
+            }]
           }
         end
 

--- a/spec/controllers/spree/api/users_controller_spec.rb
+++ b/spec/controllers/spree/api/users_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Spree::Api::UsersController, type: :controller do
         user: {
           subscriptions_attributes: [{
             id: subscription.id,
-            line_item_attributes: line_item_attributes
+            line_items_attributes: [line_item_attributes]
           }]
         }
       }
@@ -29,7 +29,7 @@ RSpec.describe Spree::Api::UsersController, type: :controller do
 
     let(:line_item_attributes) do
       {
-        id: subscription.line_item.id,
+        id: subscription.line_item_ids.first,
         quantity: 6,
         interval_length: 1,
         interval_units: 'month'
@@ -38,7 +38,7 @@ RSpec.describe Spree::Api::UsersController, type: :controller do
 
     it 'updates the subscription line items' do
       subject
-      line_item = subscription.line_item(true)
+      line_item = subscription.line_items(true).first
 
       expect(line_item).to have_attributes(line_item_attributes)
     end

--- a/spec/lib/solidus_subscriptions/processor_spec.rb
+++ b/spec/lib/solidus_subscriptions/processor_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe SolidusSubscriptions::Processor, :checkout do
     let(:order_variant_ids) { Spree::Order.last.variant_ids }
     let(:expected_ids) do
       subs = actionable_subscriptions + pending_cancellation_subscriptions
-      subs_ids = subs.map { |s| s.line_item.subscribable_id }
-      inst_ids = failed_installments.map { |i| i.subscription.line_item.subscribable_id }
+      subs_ids = subs.flat_map { |s| s.line_items.pluck(:subscribable_id) }
+      inst_ids = failed_installments.flat_map { |i| i.subscription.line_items.pluck(:subscribable_id) }
 
       subs_ids + inst_ids
     end

--- a/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
+++ b/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe SolidusSubscriptions::ConsolidatedInstallment do
 
   describe '#process', :checkout do
     subject(:order) { consolidated_installment.process }
-    let(:subscription_line_item) { installments.first.subscription.line_item }
+    let(:subscription_line_item) { installments.first.subscription.line_items.first }
 
     shared_examples 'a completed checkout' do
       it { is_expected.to be_a Spree::Order }
@@ -101,11 +101,11 @@ RSpec.describe SolidusSubscriptions::ConsolidatedInstallment do
     end
 
     context 'the variant is out of stock' do
-      let(:subscription_line_item) { installments.last.subscription.line_item }
+      let(:subscription_line_item) { installments.last.subscription.line_items.first }
 
       # Remove stock for 1 variant in the consolidated installment
       before do
-        subscribable_id = installments.first.subscription.line_item.subscribable_id
+        subscribable_id = installments.first.subscription.line_items.first.subscribable_id
         variant = Spree::Variant.find(subscribable_id)
         variant.stock_items.update_all(count_on_hand: 0, backorderable: false)
       end

--- a/spec/models/solidus_subscriptions/installment_spec.rb
+++ b/spec/models/solidus_subscriptions/installment_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe SolidusSubscriptions::Installment, type: :model do
   describe '#line_item_builder' do
     subject { installment.line_item_builder }
 
-    let(:line_item) { installment.subscription.line_item }
+    let(:line_items) { installment.subscription.line_items }
 
     it { is_expected.to be_a SolidusSubscriptions::LineItemBuilder }
-    it { is_expected.to have_attributes(subscription_line_items: [line_item]) }
+    it { is_expected.to have_attributes(subscription_line_items: line_items) }
   end
 
   describe '#out_of_stock' do

--- a/spec/models/solidus_subscriptions/installment_spec.rb
+++ b/spec/models/solidus_subscriptions/installment_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SolidusSubscriptions::Installment, type: :model do
     let(:line_item) { installment.subscription.line_item }
 
     it { is_expected.to be_a SolidusSubscriptions::LineItemBuilder }
-    it { is_expected.to have_attributes(subscription_line_item: line_item) }
+    it { is_expected.to have_attributes(subscription_line_items: [line_item]) }
   end
 
   describe '#out_of_stock' do

--- a/spec/models/solidus_subscriptions/line_item_builder_spec.rb
+++ b/spec/models/solidus_subscriptions/line_item_builder_spec.rb
@@ -1,14 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe SolidusSubscriptions::LineItemBuilder do
-  let(:builder) { described_class.new subscription_line_item }
+  let(:builder) { described_class.new subscription_line_items }
   let(:variant) { create(:variant, subscribable: true) }
-  let(:subscription_line_item) do
-    build_stubbed(:subscription_line_item, subscribable_id: variant.id)
+  let(:subscription_line_item) { subscription_line_items.first }
+  let(:subscription_line_items) do
+    build_stubbed_list(:subscription_line_item, 1, subscribable_id: variant.id)
   end
 
-  describe '#line_item' do
-    subject { builder.line_item }
+  describe '#spree_line_items' do
+    subject { builder.spree_line_items }
     let(:expected_attributes) do
       {
         variant_id: subscription_line_item.subscribable_id,
@@ -16,8 +17,11 @@ RSpec.describe SolidusSubscriptions::LineItemBuilder do
       }
     end
 
-    it { is_expected.to be_a Spree::LineItem }
-    it { is_expected.to have_attributes expected_attributes }
+    it { is_expected.to be_a Array }
+
+    it 'contains a line item with the correct attributes' do
+      expect(subject.first).to have_attributes expected_attributes
+    end
 
     context 'the variant is not subscribable' do
       let!(:variant) { create(:variant) }
@@ -32,7 +36,7 @@ RSpec.describe SolidusSubscriptions::LineItemBuilder do
 
     context 'the variant is out of stock' do
       before { create :stock_location, backorderable_default: false }
-      it { is_expected.to be_nil }
+      it { is_expected.to be_empty }
     end
   end
 end

--- a/spec/models/solidus_subscriptions/subscription_generator_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_generator_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SolidusSubscriptions::SubscriptionGenerator do
     let(:user) { subscription_line_items.first.order.user }
     let(:store) { subscription_line_items.first.order.store }
 
-    it { is_expected.to be_a Array }
+    it { is_expected.to be_a SolidusSubscriptions::Subscription }
 
     it 'creates the correct number of subscritpions' do
       expect { subject }.
@@ -18,10 +18,9 @@ RSpec.describe SolidusSubscriptions::SubscriptionGenerator do
     end
 
     it 'creates subscriptions with the correct attributes' do
-      subscription = subject.first
-      expect(subscription).to have_attributes(
+      expect(subject).to have_attributes(
         user: user,
-        line_item: subscription_line_item,
+        line_items: subscription_line_items,
         store: store
       )
     end

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
   it { is_expected.to have_many :installments }
   it { is_expected.to belong_to :user }
   it { is_expected.to belong_to :store }
-  it { is_expected.to have_one :line_item }
+  it { is_expected.to have_many :line_items }
 
   it { is_expected.to validate_presence_of :user }
   it { is_expected.to validate_presence_of :skip_count }
@@ -12,7 +12,7 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
   it { is_expected.to validate_numericality_of(:skip_count).is_greater_than_or_equal_to(0) }
   it { is_expected.to validate_numericality_of(:successive_skip_count).is_greater_than_or_equal_to(0) }
 
-  it { is_expected.to accept_nested_attributes_for :line_item }
+  it { is_expected.to accept_nested_attributes_for :line_items }
 
   describe '#cancel' do
     subject { subscription.cancel }
@@ -195,10 +195,10 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
     subject { subscription.line_item_builder }
 
     let(:subscription) { create :subscription, :with_line_item }
-    let(:line_item) { subscription.line_item }
+    let(:line_items) { subscription.line_items }
 
     it { is_expected.to be_a SolidusSubscriptions::LineItemBuilder }
-    it { is_expected.to have_attributes(subscription_line_items: [line_item]) }
+    it { is_expected.to have_attributes(subscription_line_items: line_items) }
   end
 
   describe '#processing_state' do

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
     let(:line_item) { subscription.line_item }
 
     it { is_expected.to be_a SolidusSubscriptions::LineItemBuilder }
-    it { is_expected.to have_attributes(subscription_line_item: line_item) }
+    it { is_expected.to have_attributes(subscription_line_items: [line_item]) }
   end
 
   describe '#processing_state' do

--- a/spec/overrides/spree/orders/finalize_creates_subscrptions_spec.rb
+++ b/spec/overrides/spree/orders/finalize_creates_subscrptions_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Spree::Orders::FinalizeCreatesSubscriptions do
       expect(subscription).to have_attributes(
         user_id: order.user_id,
         actionable_date: expected_actionable_date,
-        line_item: subscription_line_item
+        line_items: [subscription_line_item]
       )
     end
   end


### PR DESCRIPTION
We are going to support multiple items per subscription. This commit
changes the subscription -> subscription_line_item relationship from a
has_one to a has_many.

Most of the changes here are simply pluralization changes. Somethat are
not:

Api params now take:
`line_items_attributes instead` of `line_item_attributes` for nested params
to a subscription

`subscription_line_items_attributes` instead of
`subscription_line_item_attributes`

Only the interval and max installemnts of the first subscription_line_item is considered