### PR TITLE
Use hash syntax for enums

### DIFF
--- a/app/models/solidus_subscriptions/line_item.rb
+++ b/app/models/solidus_subscriptions/line_item.rb
@@ -25,12 +25,12 @@ module SolidusSubscriptions
       inverse_of: :line_item
     )
 
-    enum interval_units: [
-      :day,
-      :week,
-      :month,
-      :year
-    ]
+    enum interval_units: {
+      day: 0,
+      week: 1,
+      month: 2,
+      year: 3
+    }
 
     validates :subscribable_id, presence: :true
     validates :quantity, :interval_length, numericality: { greater_than: 0 }


### PR DESCRIPTION
This is much safer than the array syntax. the db indexes are explicitely
set on the model and are less likely to be accidentally changed.

These indexes are in the same order as the array was defined, no app
should notice a difference unless they have changed the order of this
array