### PR TITLE
Subs have addresses

### DIFF
--- a/apidoc/configuration.md
+++ b/apidoc/configuration.md
@@ -48,7 +48,10 @@ SolidusSubscriptions::Config.subscription_line_item_attributes = [
 # SolidusSubscriptions::Subscription attributes which are allowed to
 # be updated from user data
 
-SolidusSubscriptions::Config.subscription_attributes = [:actionable_date]
+SolidusSubscriptions::Config.subscription_attributes = [
+  :actionable_date,
+  shipping_address_attributes: Spree::PermittedAttributes.address_attributes
+]
 
 # Dispatchers (processing callbacks)
 

--- a/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
+++ b/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
@@ -3,7 +3,7 @@ class SolidusSubscriptions::Api::V1::SubscriptionsController < Spree::Api::BaseC
 
   def update
     if @subscription.update(subscription_params)
-      render json: @subscription.to_json(include: :line_items)
+      render json: @subscription.to_json(include: [:line_items, :shipping_address])
     else
       render json: @subscription.errors.to_json, status: 422
     end
@@ -33,7 +33,8 @@ class SolidusSubscriptions::Api::V1::SubscriptionsController < Spree::Api::BaseC
 
   def subscription_params
     params.require(:subscription).permit(
-      line_items_attributes: line_item_attributes
+      line_items_attributes: line_item_attributes,
+      shipping_address_attributes: Spree::PermittedAttributes.address_attributes
     )
   end
 

--- a/app/jobs/solidus_subscriptions/process_installments_job.rb
+++ b/app/jobs/solidus_subscriptions/process_installments_job.rb
@@ -15,7 +15,7 @@ module SolidusSubscriptions
        return if installment_ids.empty?
 
        installments = SolidusSubscriptions::Installment.where(id: installment_ids).
-         includes(subscription: [:line_item, :user])
+         includes(subscription: [:line_items, :user])
        ConsolidatedInstallment.new(installments).process
      end
   end

--- a/app/models/solidus_subscriptions/consolidated_installment.rb
+++ b/app/models/solidus_subscriptions/consolidated_installment.rb
@@ -113,7 +113,7 @@ module SolidusSubscriptions
     end
 
     def ship_address
-      user.ship_address
+      subscription.shipping_address || user.ship_address
     end
 
     def active_card

--- a/app/models/solidus_subscriptions/line_item.rb
+++ b/app/models/solidus_subscriptions/line_item.rb
@@ -71,11 +71,10 @@ module SolidusSubscriptions
     # subscription orders. It is a frozen duplicate of the current order and
     # cannot be saved
     def dummy_order
-      if spree_line_item
-        spree_line_item.order.dup.freeze
-      else
-        Spree::Order.create.freeze
-      end
+      order = spree_line_item ? spree_line_item.order.dup : Spree::Order.create
+      order.ship_address = subscription.shipping_address || subscription.user.ship_address if subscription
+
+      order.freeze
     end
 
     # A place holder for calculating dynamic values needed to display in the cart

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -14,7 +14,7 @@ module SolidusSubscriptions
     validates :user, presence: :true
     validates :skip_count, :successive_skip_count, presence: true, numericality: { greater_than_or_equal_to: 0 }
 
-    accepts_nested_attributes_for :line_items
+    accepts_nested_attributes_for :line_items, :shipping_address
 
     # The following methods are delegated to the associated
     # SolidusSubscriptions::LineItem

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -9,6 +9,7 @@ module SolidusSubscriptions
     has_many :line_items, class_name: 'SolidusSubscriptions::LineItem'
     has_many :installments, class_name: 'SolidusSubscriptions::Installment'
     belongs_to :store, class_name: 'Spree::Store'
+    belongs_to :shipping_address, class_name: 'Spree::Address'
 
     validates :user, presence: :true
     validates :skip_count, :successive_skip_count, presence: true, numericality: { greater_than_or_equal_to: 0 }

--- a/app/models/solidus_subscriptions/subscription_generator.rb
+++ b/app/models/solidus_subscriptions/subscription_generator.rb
@@ -12,10 +12,16 @@ module SolidusSubscriptions
     def self.activate(subscription_line_items)
       return if subscription_line_items.empty?
 
-      user = subscription_line_items.first.order.user
-      store = subscription_line_items.first.order.store
+      order = subscription_line_items.first.order
 
-      Subscription.create!(user: user, line_items: subscription_line_items, store: store) do |sub|
+      subscription_attributes = {
+        user: order.user,
+        line_items: subscription_line_items,
+        store: order.store,
+        shipping_address: order.ship_address
+      }
+
+      Subscription.create!(subscription_attributes) do |sub|
         sub.actionable_date = sub.next_actionable_date
       end
     end

--- a/db/migrate/20161223152905_add_address_id_to_solidus_subscriptions_subscriptions.rb
+++ b/db/migrate/20161223152905_add_address_id_to_solidus_subscriptions_subscriptions.rb
@@ -1,0 +1,7 @@
+class AddAddressIdToSolidusSubscriptionsSubscriptions < ActiveRecord::Migration
+  def change
+    add_reference :solidus_subscriptions_subscriptions, :shipping_address
+    add_index :solidus_subscriptions_subscriptions, :shipping_address_id, name: :index_subscription_shipping_address_id
+    add_foreign_key :solidus_subscriptions_subscriptions, :spree_addresses, column: :shipping_address_id
+  end
+end

--- a/lib/solidus_subscriptions/config.rb
+++ b/lib/solidus_subscriptions/config.rb
@@ -73,7 +73,7 @@ module SolidusSubscriptions
     #   :subscribable_id
     # ]
     # ```
-
+    #
     # This configuration also easily allows the gem to be customized to track
     # more information on the subcriptions line items.
     mattr_accessor(:subscription_line_item_attributes) do
@@ -88,6 +88,11 @@ module SolidusSubscriptions
 
     # SolidusSubscriptions::Subscription attributes which are allowed to
     # be updated from user data
-    mattr_accessor(:subscription_attributes) { [:actionable_date] }
+    mattr_accessor(:subscription_attributes) do
+      [
+        :actionable_date,
+        shipping_address_attributes: Spree::PermittedAttributes.address_attributes
+      ]
+    end
   end
 end

--- a/lib/solidus_subscriptions/processor.rb
+++ b/lib/solidus_subscriptions/processor.rb
@@ -1,6 +1,7 @@
 # This class is responsible for finding subscriptions and installments
 # which need to be processed. It will group them together by user and attempts
-# to process them together.
+# to process them together. Subscriptions will also be grouped by their
+# shiping address id.
 #
 # This class passes the reponsibility of actually creating the order off onto
 # the consolidated installment class.
@@ -55,7 +56,15 @@ module SolidusSubscriptions
     # Create `ProcessInstallmentsJob`s for the users used to initalize the
     # instance
     def build_jobs
-      users.map { |user| ProcessInstallmentsJob.perform_later installments(user).map(&:id) }
+      users.map do |user|
+        installemts_by_address_and_user = installments(user).group_by do |i|
+          i.subscription.shipping_address_id
+        end
+
+        installemts_by_address_and_user.values.each do |grouped_installments|
+          ProcessInstallmentsJob.perform_later grouped_installments.map(&:id)
+        end
+      end
     end
 
     private
@@ -63,7 +72,7 @@ module SolidusSubscriptions
     def subscriptions_by_id
       @subscriptions_by_id ||= Subscription.
         actionable.
-        includes(:line_item, :user).
+        includes(:line_items, :user).
         where(user_id: user_ids).
         group_by(&:user_id)
     end

--- a/lib/solidus_subscriptions/testing_support/factories/subscription_factory.rb
+++ b/lib/solidus_subscriptions/testing_support/factories/subscription_factory.rb
@@ -15,6 +15,10 @@ FactoryGirl.define do
       line_items { build_list :subscription_line_item, 1, *line_item_traits }
     end
 
+    trait :with_address do
+      association :shipping_address, factory: :address
+    end
+
     trait :actionable do
       with_line_item
       actionable_date { Time.zone.now.yesterday }

--- a/spec/controllers/solidus_subscriptions/api/v1/subscriptions_controller_spec.rb
+++ b/spec/controllers/solidus_subscriptions/api/v1/subscriptions_controller_spec.rb
@@ -46,7 +46,17 @@ RSpec.describe SolidusSubscriptions::Api::V1::SubscriptionsController, type: :co
         line_items_attributes: [{
           id: subscription.line_items.first.id,
           quantity: 6
-        }]
+        }],
+        shipping_address_attributes: {
+          firstname: 'Ash',
+          lastname: 'Ketchum',
+          address1: '1 Rainbow Road',
+          city: 'Palette Town',
+          country_id: create(:country).id,
+          state_id: create(:state).id,
+          phone: '999-999-999',
+          zipcode: '10001'
+        }
       }
     end
 

--- a/spec/lib/solidus_subscriptions/processor_spec.rb
+++ b/spec/lib/solidus_subscriptions/processor_spec.rb
@@ -74,6 +74,16 @@ RSpec.describe SolidusSubscriptions::Processor, :checkout do
         to change { subs.reload.state }.
         from('pending_cancellation').to('canceled')
     end
+
+    context 'the subscriptions have different shipping addresses' do
+      let!(:sub_to_different_address) do
+        create(:subscription, :actionable, :with_address, user: user)
+      end
+
+      it 'creates an order for each shipping address' do
+        expect { subject }.to change { Spree::Order.complete.count }.by 2
+      end
+    end
   end
 
   describe '.run' do

--- a/spec/models/solidus_subscriptions/line_item_spec.rb
+++ b/spec/models/solidus_subscriptions/line_item_spec.rb
@@ -80,6 +80,26 @@ RSpec.describe SolidusSubscriptions::LineItem, type: :model do
         expect(subject.variant_id).to eq line_item.subscribable_id
       end
     end
+
+    context 'with an associated subscription' do
+      context 'the associated subscription has an address' do
+        let(:line_item) do
+          create(:subscription_line_item, :with_subscription, subscription_traits: [:with_address])
+        end
+
+        it 'uses the subscription shipping address' do
+          expect(subject.order.ship_address).to eq line_item.subscription.shipping_address
+        end
+      end
+
+      context 'the associated subscription has no address' do
+        let(:line_item) { create(:subscription_line_item, :with_subscription) }
+
+        it 'uses the subscription users shipping address' do
+          expect(subject.order.ship_address).to eq line_item.subscription.user.ship_address
+        end
+      end
+    end
   end
 
   describe "#update_actionable_date_if_interval_changed" do

--- a/spec/models/solidus_subscriptions/subscription_generator_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_generator_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe SolidusSubscriptions::SubscriptionGenerator do
       expect(subject).to have_attributes(
         user: user,
         line_items: subscription_line_items,
+        shipping_address: subscription_line_item.spree_line_item.order.ship_address,
         store: store
       )
     end

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
   it { is_expected.to belong_to :user }
   it { is_expected.to belong_to :store }
   it { is_expected.to have_many :line_items }
+  it { is_expected.to belong_to :shipping_address }
 
   it { is_expected.to validate_presence_of :user }
   it { is_expected.to validate_presence_of :skip_count }


### PR DESCRIPTION
In order to allow for users to manage subscriptions for other people
(family members etc) we are going to store a shipping address directly
on the subscription. This way a user can ship different subscriptions to
different addresses

The default shipping address for a subscription is the shipping address
of the order that purchased it.

Subscriptions are grouped together and processed by user and and by shipping address.

```
A user has 3 subscriptions (A, B and C). A and B have the same shipping
address, but C will be shipped to a different location.

The processor will group and process installments for A and B together
and they will be fulfilled by the same order.

A second order will be created to fulfill C.
```

The api allows subscription shipping addresses to be updated as a nested
parameter