### PR TITLE
Remove some n+1 queries from processing

### DIFF
--- a/app/jobs/solidus_subscriptions/process_installments_job.rb
+++ b/app/jobs/solidus_subscriptions/process_installments_job.rb
@@ -7,12 +7,15 @@ module SolidusSubscriptions
 
      # Process a collection of installments
      #
-     # @param installments [Array<SolidusSubscriptions::Installment>] The
+     # @param installment_ids [Array<Integer>] The ids of the
      #   installments to be processed together and fulfilled by the same order
      #
      # @return [Spree::Order] The order which fulfills the list of installments
-     def perform(installments)
-       return if installments.empty?
+     def perform(installment_ids)
+       return if installment_ids.empty?
+
+       installments = SolidusSubscriptions::Installment.where(id: installment_ids).
+         includes(subscription: [:line_item, :user])
        ConsolidatedInstallment.new(installments).process
      end
   end


### PR DESCRIPTION
The processor looks up a number of users, subscriptions and installments
and passes them off to an Active Job.

Before we were doing a number of n+1 queries and relying on the rails
global id when passing objects to the consolidated installments.

This commit removes the greedy queries and passes a list of ids to the
active job object so that all affected objects can be looked up in a
single query

Local speed test processing 100 subscriptions all belonging to a single user (Postgres):

before: 7404.390109999999 milliseconds
after: 6939.091705 milliseconds