### PR TITLE
Change dates to date times

### DIFF
--- a/app/models/solidus_subscriptions/installment.rb
+++ b/app/models/solidus_subscriptions/installment.rb
@@ -119,7 +119,7 @@ module SolidusSubscriptions
     end
 
     def next_actionable_date
-      Date.current + Config.reprocessing_interval
+      (DateTime.current + Config.reprocessing_interval).beginning_of_minute
     end
   end
 end

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -154,7 +154,8 @@ module SolidusSubscriptions
     #   eligible to be processed.
     def next_actionable_date
       return nil unless active?
-      (actionable_date || Time.zone.now) + interval
+      new_date = (actionable_date || Time.zone.now)
+      (new_date + interval).beginning_of_minute
     end
 
     # Advance the actionable date to the next_actionable_date value. Will modify

--- a/db/migrate/20170111224458_change_subscription_actionable_date_to_datetime.rb
+++ b/db/migrate/20170111224458_change_subscription_actionable_date_to_datetime.rb
@@ -1,0 +1,5 @@
+class ChangeSubscriptionActionableDateToDatetime < ActiveRecord::Migration
+  def change
+    change_column :solidus_subscriptions_subscriptions, :actionable_date, :datetime
+  end
+end

--- a/db/migrate/20170111232801_change_inteval_actionable_date_to_datetime.rb
+++ b/db/migrate/20170111232801_change_inteval_actionable_date_to_datetime.rb
@@ -1,0 +1,5 @@
+class ChangeIntevalActionableDateToDatetime < ActiveRecord::Migration
+  def change
+    change_column :solidus_subscriptions_installments, :actionable_date, :datetime
+  end
+end

--- a/lib/solidus_subscriptions/testing_support/factories/subscription_factory.rb
+++ b/lib/solidus_subscriptions/testing_support/factories/subscription_factory.rb
@@ -17,12 +17,12 @@ FactoryGirl.define do
 
     trait :actionable do
       with_line_item
-      actionable_date { Time.zone.now.yesterday }
+      actionable_date { Time.zone.now.yesterday.beginning_of_minute }
     end
 
     trait :not_actionable do
       with_line_item
-      actionable_date { Time.zone.now.tomorrow }
+      actionable_date { Time.zone.now.tomorrow.beginning_of_minute }
     end
 
     trait(:pending_cancellation) do

--- a/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
+++ b/spec/models/solidus_subscriptions/consolidated_installment_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe SolidusSubscriptions::ConsolidatedInstallment do
         variant.stock_items.update_all(count_on_hand: 0, backorderable: false)
       end
 
-      let(:expected_date) { Date.current + SolidusSubscriptions::Config.reprocessing_interval }
+      let(:expected_date) { (DateTime.current + SolidusSubscriptions::Config.reprocessing_interval).beginning_of_minute }
 
       it 'creates a failed installment detail' do
         subject
@@ -135,7 +135,7 @@ RSpec.describe SolidusSubscriptions::ConsolidatedInstallment do
 
     context 'the payment fails' do
       let(:credit_card) { create(:credit_card, default: true) }
-      let(:expected_date) { Date.current + SolidusSubscriptions::Config.reprocessing_interval }
+      let(:expected_date) { (DateTime.current + SolidusSubscriptions::Config.reprocessing_interval).beginning_of_minute }
 
       before do
         consolidated_installment.user.credit_cards << credit_card
@@ -195,7 +195,7 @@ RSpec.describe SolidusSubscriptions::ConsolidatedInstallment do
     end
 
     context 'there is an aribitrary failure' do
-      let(:expected_date) { Date.current + SolidusSubscriptions::Config.reprocessing_interval }
+      let(:expected_date) { (DateTime.current + SolidusSubscriptions::Config.reprocessing_interval).beginning_of_minute }
 
       before do
         allow(consolidated_installment).to receive(:populate).and_raise('arbitrary runtime error')

--- a/spec/models/solidus_subscriptions/installment_spec.rb
+++ b/spec/models/solidus_subscriptions/installment_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe SolidusSubscriptions::Installment, type: :model do
     subject { installment.out_of_stock }
 
     let(:expected_date) do
-      Date.current + SolidusSubscriptions::Config.reprocessing_interval
+      (DateTime.current + SolidusSubscriptions::Config.reprocessing_interval).beginning_of_minute
     end
 
     it { is_expected.to be_a SolidusSubscriptions::InstallmentDetail }
@@ -73,7 +73,7 @@ RSpec.describe SolidusSubscriptions::Installment, type: :model do
     let(:order) { create :order }
 
     let(:expected_date) do
-      Date.current + SolidusSubscriptions::Config.reprocessing_interval
+      (DateTime.current + SolidusSubscriptions::Config.reprocessing_interval).beginning_of_minute
     end
 
     it { is_expected.to be_a SolidusSubscriptions::InstallmentDetail }
@@ -128,7 +128,7 @@ RSpec.describe SolidusSubscriptions::Installment, type: :model do
     let(:order) { create :order }
 
     let(:expected_date) do
-      Date.current + SolidusSubscriptions::Config.reprocessing_interval
+      (DateTime.current + SolidusSubscriptions::Config.reprocessing_interval).beginning_of_minute
     end
 
     it { is_expected.to be_a SolidusSubscriptions::InstallmentDetail }

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
 
     let(:total_skips) { 0 }
     let(:successive_skips) { 0 }
-    let(:expected_date) { 1.month.from_now.to_date }
+    let(:expected_date) { 1.month.from_now.beginning_of_minute }
 
     let(:subscription) do
       create(

--- a/spec/overrides/spree/orders/finalize_creates_subscrptions_spec.rb
+++ b/spec/overrides/spree/orders/finalize_creates_subscrptions_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Spree::Orders::FinalizeCreatesSubscriptions do
 
     let(:order) { create :order, :with_subscription_line_items }
     let(:subscription_line_item) { order.subscription_line_items.last }
-    let(:expected_actionable_date) { (Date.current + subscription_line_item.interval).to_date }
+    let(:expected_actionable_date) { (DateTime.current + subscription_line_item.interval).beginning_of_minute }
 
     around { |e| Timecop.freeze { e.run } }
 

--- a/spec/requests/solidus_subscriptions/api/v1/subscriptions_spec.rb
+++ b/spec/requests/solidus_subscriptions/api/v1/subscriptions_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Subscription endpoints", type: :request do
     before { Timecop.freeze(Date.parse("2016-09-26")) }
     after  { Timecop.return }
 
-    let(:expected_date) { "2016-10-27" }
+    let(:expected_date) { "2016-10-27T00:00:00.000Z" }
 
     it "returns the updated record", :aggregate_failures do
       post solidus_subscriptions.skip_api_v1_subscription_path(subscription), token: user.spree_api_key


### PR DESCRIPTION
Increase actionable date granularity by tracking it as a date time